### PR TITLE
Optimize topoplot grid interpolation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-28 - Vectorizing Bi-harmonic Spline Evaluation in topoplot
+**Learning:** Nested Python loops in `griddata_v4` for evaluating query points were a major bottleneck. Repeatedly entering/exiting `np.errstate` context managers inside these loops added further overhead.
+**Action:** Use NumPy broadcasting and the `@` operator to vectorize evaluation across the entire query grid at once. Move context managers outside the core calculation.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2026-06-28 - Vectorizing Bi-harmonic Spline Evaluation in topoplot
-**Learning:** Nested Python loops in `griddata_v4` for evaluating query points were a major bottleneck. Repeatedly entering/exiting `np.errstate` context managers inside these loops added further overhead.
-**Action:** Use NumPy broadcasting and the `@` operator to vectorize evaluation across the entire query grid at once. Move context managers outside the core calculation.

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -45,19 +45,17 @@ def griddata_v4(x, y, v, xq, yq):
         # If still singular, use pseudoinverse as last resort
         weights = np.linalg.pinv(g_reg) @ v
 
-    # Initialize output array
-    m, n = xq.shape
-    vq = np.zeros_like(xq)
+    # Evaluate at requested points (vectorized)
+    # q is (M, N), xy is (L,) -> d_q is (M, N, L)
+    q = xq + 1j * yq
+    d_q = np.abs(q[:, :, np.newaxis] - xy[np.newaxis, np.newaxis, :])
 
-    # Evaluate at requested points
-    xy = xy[:, None]  # Make it column vector for broadcasting
-    for i in range(m):
-        for j in range(n):
-            d = np.abs(xq[i, j] + 1j * yq[i, j] - xy.ravel())
-            with np.errstate(divide='ignore', invalid='ignore'):
-                g = (d**2) * (np.log(d) - 1)  # Green's function
-            g[d == 0] = 0  # Handle Green's function at zero
-            vq[i, j] = np.dot(g, weights)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        g_q = (d_q**2) * (np.log(d_q) - 1)  # Green's function
+    g_q[d_q == 0] = 0  # Handle Green's function at zero
+
+    # Weights is (L,), g_q is (M, N, L) -> vq is (M, N)
+    vq = g_q @ weights
 
     return vq
 


### PR DESCRIPTION
Vectorize the bi-harmonic spline evaluation in griddata_v4 with NumPy broadcasting and matrix multiplication. Preserve zero-distance handling and numerical parity while reducing Python loop overhead.