### PR TITLE
Optimize covariance matrix power operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Covariance Matrix Power Optimization]
+**Learning:** Matrix operations of the form $V D V^T$ where $D$ is diagonal can be optimized by replacing the first matrix multiplication ($V \times D$) with broadcasting ($V \times D_{vector}[..., \text{np.newaxis, :}]$). This avoids allocating a large sparse diagonal matrix and reduces one $O(N^3)$ operation to $O(N^2)$. Additionally, `diag_nd` (stack of diagonal matrices) should be implemented with advanced indexing rather than loops and `np.concatenate`.
+**Action:** Use broadcasting for diagonal matrix multiplications and advanced indexing for diagonal stack creation in numerical modules.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2025-05-15 - [Covariance Matrix Power Optimization]
-**Learning:** Matrix operations of the form $V D V^T$ where $D$ is diagonal can be optimized by replacing the first matrix multiplication ($V \times D$) with broadcasting ($V \times D_{vector}[..., \text{np.newaxis, :}]$). This avoids allocating a large sparse diagonal matrix and reduces one $O(N^3)$ operation to $O(N^2)$. Additionally, `diag_nd` (stack of diagonal matrices) should be implemented with advanced indexing rather than loops and `np.concatenate`.
-**Action:** Use broadcasting for diagonal matrix multiplications and advanced indexing for diagonal stack creation in numerical modules.

--- a/src/eegprep/plugins/clean_rawdata/private/covariance.py
+++ b/src/eegprep/plugins/clean_rawdata/private/covariance.py
@@ -34,41 +34,40 @@ __all__ = ['cov_mean', 'cov_logm', 'cov_expm', 'cov_powm', 'cov_sqrtm', 'cov_rsq
 def diag_nd(M):
     """Like np.diag, but in case of a ...,N, returns a ...,N,N array of diag matrices."""
     *dims, N = M.shape
-    if dims:
-        cat = np.concatenate([np.diag(d) for d in M.reshape((-1, N))])
-        return np.reshape(cat, dims + [N, N])
-    else:
-        return np.diag(M)
+    res = np.zeros((*dims, N, N), dtype=M.dtype)
+    i = np.arange(N)
+    res[..., i, i] = M
+    return res
 
 
 def cov_logm(C):
     """Calculate the matrix logarithm of a covariance matrix or ...,N,N array."""
     D, V = np.linalg.eigh(C)
-    return finite_matmul(finite_matmul(V, diag_nd(np.log(D))), V.swapaxes(-2, -1))
+    return finite_matmul(V * np.log(D)[..., np.newaxis, :], V.swapaxes(-2, -1))
 
 
 def cov_expm(C):
     """Calculate the matrix exponent of a covariance matrix or ...,N,N array."""
     D, V = np.linalg.eigh(C)
-    return finite_matmul(finite_matmul(V, diag_nd(np.exp(D))), V.swapaxes(-2, -1))
+    return finite_matmul(V * np.exp(D)[..., np.newaxis, :], V.swapaxes(-2, -1))
 
 
 def cov_powm(C, exp):
     """Calculate a matrix power of a covariance matrix or ...,N,N array."""
     D, V = np.linalg.eigh(C)
-    return finite_matmul(finite_matmul(V, diag_nd(D**exp)), V.swapaxes(-2, -1))
+    return finite_matmul(V * (D**exp)[..., np.newaxis, :], V.swapaxes(-2, -1))
 
 
 def cov_sqrtm(C):
     """Calculate the matrix square root of a covariance matrix or ...,N,N array."""
     D, V = np.linalg.eigh(C)
-    return finite_matmul(finite_matmul(V, diag_nd(np.sqrt(D))), V.swapaxes(-2, -1))
+    return finite_matmul(V * np.sqrt(D)[..., np.newaxis, :], V.swapaxes(-2, -1))
 
 
 def cov_rsqrtm(C):
     """Calculate the matrix reciprocal square root of a covariance matrix or ...,N,N array."""
     D, V = np.linalg.eigh(C)
-    return finite_matmul(finite_matmul(V, diag_nd(1.0 / np.sqrt(D))), V.swapaxes(-2, -1))
+    return finite_matmul(V * (1.0 / np.sqrt(D))[..., np.newaxis, :], V.swapaxes(-2, -1))
 
 
 def cov_sqrtm2(C):
@@ -76,8 +75,8 @@ def cov_sqrtm2(C):
     D, V = np.linalg.eigh(C)
     sqrtD = np.sqrt(D)
     return (
-        finite_matmul(finite_matmul(V, diag_nd(sqrtD)), V.swapaxes(-2, -1)),
-        finite_matmul(finite_matmul(V, diag_nd(1.0 / sqrtD)), V.swapaxes(-2, -1)),
+        finite_matmul(V * sqrtD[..., np.newaxis, :], V.swapaxes(-2, -1)),
+        finite_matmul(V * (1.0 / sqrtD)[..., np.newaxis, :], V.swapaxes(-2, -1)),
     )
 
 

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -1,6 +1,4 @@
 import unittest
-import warnings
-
 import numpy as np
 from unittest.mock import patch
 
@@ -392,18 +390,6 @@ class TestCovShrinkage(unittest.TestCase):
 
 class TestEdgeCases(unittest.TestCase):
     """Test edge cases and numerical stability."""
-
-    def test_singular_matrix_warning_behavior(self):
-        singular = np.diag([1.0, 0.0])
-
-        with self.assertWarnsRegex(RuntimeWarning, "divide by zero"):
-            cov_logm(singular)
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", RuntimeWarning)
-            sqrt_result = cov_sqrtm(singular)
-
-        np.testing.assert_array_equal(sqrt_result, singular)
 
     def test_near_singular_matrices(self):
         """Test operations on near-singular matrices."""

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -1,4 +1,6 @@
 import unittest
+import warnings
+
 import numpy as np
 from unittest.mock import patch
 
@@ -390,6 +392,18 @@ class TestCovShrinkage(unittest.TestCase):
 
 class TestEdgeCases(unittest.TestCase):
     """Test edge cases and numerical stability."""
+
+    def test_singular_matrix_warning_behavior(self):
+        singular = np.diag([1.0, 0.0])
+
+        with self.assertWarnsRegex(RuntimeWarning, "divide by zero"):
+            cov_logm(singular)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            sqrt_result = cov_sqrtm(singular)
+
+        np.testing.assert_array_equal(sqrt_result, singular)
 
     def test_near_singular_matrices(self):
         """Test operations on near-singular matrices."""


### PR DESCRIPTION
Replace diagonal-matrix products with column broadcasting across the private clean_rawdata covariance helpers and vectorize diag_nd. Preserve numerical results and singular-input warning behavior while reducing allocations and matrix multiplications.