### PR TITLE
Match EEGLAB pop_prop channel and component properties figure

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,7 +16,9 @@ Unreleased
   computed from the raw per-epoch data, and component spectra are scaled by the component
   map power (``mapnorm``) so their levels match EEGLAB. Channel maps mark the selected
   channel's location, and the spectrum y-axis stays tight to the plotted frequency band
-  instead of stretching to out-of-view frequencies.
+  instead of stretching to out-of-view frequencies. The ERP average panel is labeled "ERP"
+  for channels and left blank for components, since ICA component activations are unitless,
+  matching EEGLAB.
 - Scalp maps now render with EEGLAB's left-right orientation. ``topoplot``, ``plottopo``,
   and ``erpimage`` previously mirrored electrode markers, labels, and interpolated data
   along the left-right axis; channel positions now match EEGLAB (F4 on the right, F3 on the

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,7 +15,8 @@ Unreleased
   full ERP image (reusing ``erpimage``) instead of a single averaged trace, the spectrum is
   computed from the raw per-epoch data, and component spectra are scaled by the component
   map power (``mapnorm``) so their levels match EEGLAB. Channel maps mark the selected
-  channel's location.
+  channel's location, and the spectrum y-axis stays tight to the plotted frequency band
+  instead of stretching to out-of-view frequencies.
 - Scalp maps now render with EEGLAB's left-right orientation. ``topoplot``, ``plottopo``,
   and ``erpimage`` previously mirrored electrode markers, labels, and interpolated data
   along the left-right axis; channel positions now match EEGLAB (F4 on the right, F3 on the

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,12 @@ the `GitHub Releases <https://github.com/sccn/eegprep/releases>`_ page.
 Unreleased
 ==========
 
+- ``pop_prop`` (Plot > Channel/Component properties) now matches EEGLAB's three-panel
+  layout: a scalp map, an ERP image, and the activity power spectrum. The ERP panel is a
+  full ERP image (reusing ``erpimage``) instead of a single averaged trace, the spectrum is
+  computed from the raw per-epoch data, and component spectra are scaled by the component
+  map power (``mapnorm``) so their levels match EEGLAB. Channel maps mark the selected
+  channel's location.
 - Scalp maps now render with EEGLAB's left-right orientation. ``topoplot``, ``plottopo``,
   and ``erpimage`` previously mirrored electrode markers, labels, and interpolated data
   along the left-right axis; channel positions now match EEGLAB (F4 on the right, F3 on the

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,7 +18,9 @@ Unreleased
   channel's location, and the spectrum y-axis stays tight to the plotted frequency band
   instead of stretching to out-of-view frequencies. The ERP average panel is labeled "ERP"
   for channels and left blank for components, since ICA component activations are unitless,
-  matching EEGLAB.
+  matching EEGLAB. The ERP trace now sits flush beneath the ERP image (only the trace carries
+  the time axis), and the "pop_prop() - <name> properties" label is shown in the window title
+  bar rather than on the canvas, as EEGLAB does.
 - Scalp maps now render with EEGLAB's left-right orientation. ``topoplot``, ``plottopo``,
   and ``erpimage`` previously mirrored electrode markers, labels, and interpolated data
   along the left-right axis; channel positions now match EEGLAB (F4 on the right, F3 on the

--- a/src/eegprep/functions/popfunc/pop_prop.py
+++ b/src/eegprep/functions/popfunc/pop_prop.py
@@ -23,7 +23,7 @@ from eegprep.functions.popfunc.plot_utils import (
     show_figures,
 )
 from eegprep.functions.sigprocfunc.erpimage import erpimage
-from eegprep.functions.sigprocfunc.spectopo import compute_spectra
+from eegprep.functions.sigprocfunc.spectopo import compute_spectra, frequency_window, spectra_ylim
 from eegprep.functions.sigprocfunc.topoplot import plot_channel_location, topoplot
 
 # EEGLAB pop_prop() spectrum-axis label and 3-contour component map. EEGLAB draws the
@@ -238,9 +238,13 @@ def _draw_spectrum(ax: Any, EEG: dict[str, Any], spectrum_input: np.ndarray, spe
         mapnorm=mapnorm,
     )
     ax.plot(freqs, spectra[0], color=EEGLAB_RED)
-    freqrange = numeric_vector(spec_options.get("freqrange", []))
-    if freqrange.size == 2:
-        ax.set_xlim(float(freqrange[0]), float(freqrange[1]))
+    # Match spectopo: x-limits from the requested band, y-limits hugging the data in that
+    # band (EEGLAB's 1/7 margin), so the axis stays tight to the visible spectrum.
+    low, high, min_idx, max_idx = frequency_window(freqs, np.asarray([]), spec_options.get("freqrange", []))
+    ax.set_xlim(low, high)
+    y_low, y_high = spectra_ylim(spectra, min_idx, max_idx)
+    if np.isfinite(y_low) and np.isfinite(y_high) and y_high > y_low:
+        ax.set_ylim(y_low, y_high)
     ax.set_xlabel("Frequency (Hz)")
     ax.set_ylabel(SPECTRUM_YLABEL)
     ax.set_title("Activity power spectrum")

--- a/src/eegprep/functions/popfunc/pop_prop.py
+++ b/src/eegprep/functions/popfunc/pop_prop.py
@@ -166,7 +166,11 @@ def _plot_one_property(EEG: dict[str, Any], typecomp: int, index: int, spec_opt:
             raise ValueError("component index is outside available ICA components")
         trace = acts[index - 1]
         basename = f"IC{index}"
-        topoplot(maps[:, index - 1], map_chanlocs, axes=topo_ax, numcontour=COMPONENT_MAP_NUMCONTOUR)
+        # maplimits='absmax' centers the color axis on 0 (EEGLAB topoplot default), so the
+        # map is not forced to matplotlib's asymmetric [min, max] auto range.
+        topoplot(
+            maps[:, index - 1], map_chanlocs, axes=topo_ax, numcontour=COMPONENT_MAP_NUMCONTOUR, maplimits="absmax"
+        )
         spectrum_input = acts[index - 1 : index]
         mapnorm = np.asarray(EEG["icawinv"], dtype=float)[:, index - 1]
     topo_ax.set_title(basename, fontsize=14)

--- a/src/eegprep/functions/popfunc/pop_prop.py
+++ b/src/eegprep/functions/popfunc/pop_prop.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import CallbackSpec, ControlSpec, DialogSpec
+from eegprep.functions.popfunc._chanutils import chanlocs_as_list
 from eegprep.functions.popfunc._property_browser import property_activity_browser
 from eegprep.functions.popfunc.plot_utils import (
     channel_labels,
@@ -21,8 +22,13 @@ from eegprep.functions.popfunc.plot_utils import (
     parse_plot_options_text,
     show_figures,
 )
+from eegprep.functions.sigprocfunc.erpimage import erpimage
 from eegprep.functions.sigprocfunc.spectopo import compute_spectra
-from eegprep.functions.sigprocfunc.topoplot import topoplot
+from eegprep.functions.sigprocfunc.topoplot import plot_channel_location, topoplot
+
+# EEGLAB pop_prop() spectrum-axis label and single-channel marker size.
+SPECTRUM_YLABEL = r"Power 10*log$_{10}$($\mu$V$^2$/Hz)"
+CHANNEL_MARKER_SIZE = 80
 
 
 def pop_prop(
@@ -125,52 +131,107 @@ def _run_gui(EEG: dict[str, Any], *, typecomp: int, renderer: Any | None = None)
 
 
 def _plot_one_property(EEG: dict[str, Any], typecomp: int, index: int, spec_opt: Any):
+    """Build the EEGLAB three-panel figure: scalp map, ERP image, power spectrum."""
     data = eeg_epoch_data(EEG)
     times = eeg_times_ms(EEG)
-    labels = channel_labels(EEG)
-    fig = plt.figure(figsize=(8, 6))
-    topo_ax = fig.add_subplot(2, 2, 1)
-    erp_ax = fig.add_subplot(2, 2, 2)
-    spec_ax = fig.add_subplot(2, 1, 2)
+    trials = int(EEG.get("trials", 1) or 1)
+
+    fig = plt.figure(figsize=(5, 5), layout="constrained")  # EEGLAB uses a 500x500 square
+    top, bottom = fig.subfigures(2, 1, height_ratios=(3, 2))
+    topo_sf, erp_sf = top.subfigures(1, 2, width_ratios=(2, 3))
+    topo_ax = topo_sf.add_subplot(1, 1, 1)
+    spec_ax = bottom.add_subplot(1, 1, 1)
+
     if typecomp:
         if index < 1 or index > data.shape[0]:
             raise ValueError("channel index is outside available channels")
         trace = data[index - 1]
-        topoplot(index, EEG.get("chanlocs", []), axes=topo_ax, style="blank", electrodes="off")
-        title = f"Channel {labels[index - 1]}"
+        basename = f"Channel {index}"
+        plot_channel_location(topo_ax, chanlocs_as_list(EEG.get("chanlocs", [])), index, markersize=CHANNEL_MARKER_SIZE)
+        spectrum_input = data[index - 1 : index]
+        mapnorm = None
     else:
         acts = component_activations(EEG)
         maps, map_chanlocs = component_map_data(EEG)
         if index < 1 or index > acts.shape[0]:
             raise ValueError("component index is outside available ICA components")
         trace = acts[index - 1]
+        basename = f"IC{index}"
         topoplot(maps[:, index - 1], map_chanlocs, axes=topo_ax, electrodes="off")
-        title = f"IC {index}"
+        spectrum_input = acts[index - 1 : index]
+        mapnorm = np.asarray(EEG["icawinv"], dtype=float)[:, index - 1]
+    topo_ax.set_title(basename, fontsize=14)
+
+    _draw_erp_image(erp_sf, trace, times, trials, basename, float(EEG.get("srate", 1) or 1))
+    _draw_spectrum(spec_ax, EEG, spectrum_input, spec_opt, mapnorm)
+    fig.suptitle(f"pop_prop() - {basename} properties", fontweight="bold")
+    return fig
+
+
+def _draw_erp_image(
+    container: Any, trace: np.ndarray, times: np.ndarray, trials: int, basename: str, srate: float
+) -> None:
+    """Draw the ERP-image panel, offset-subtracted like EEGLAB nan_mean."""
     trace_2d = trace if trace.ndim == 2 else trace[:, np.newaxis]
-    erp_ax.plot(times, np.nanmean(trace_2d, axis=1), color="black")
-    erp_ax.axhline(0, color="0.7", linewidth=0.6)
-    erp_ax.set_xlabel("Time (ms)")
-    erp_ax.set_ylabel("uV")
+    if trials > 1:
+        offset = float(np.nanmean(trace_2d))
+        smooth = 1 if trials < 6 else 3
+        erpimage(
+            trace_2d - offset,
+            times=times,
+            title=f"{basename} activity (global offset {offset:.3f})",
+            smooth=smooth,
+            caxis=2.0 / 3.0,
+            cbar=True,
+            plot_erp=True,
+            target=container,
+        )
+    else:
+        _draw_continuous_erp_image(container, trace_2d.reshape(-1), srate)
+
+
+def _draw_continuous_erp_image(container: Any, samples: np.ndarray, srate: float) -> None:
+    """Reshape continuous data into ~1s lines for an ERP image (EEGLAB pop_prop)."""
+    offset = float(np.nanmean(samples))
+    lines = 200.0
+    while samples.size < lines * srate:
+        lines *= 0.9
+    lines = int(round(lines))
+    if lines <= 2:
+        ax = container.add_subplot(1, 1, 1)
+        ax.axis("off")
+        ax.text(0.1, 0.3, "No ERP image plotted\nfor small continuous data")
+        return
+    frames = samples.size // lines
+    # EEGLAB reshapes column-major into (frames, lines); the degenerate eegtimes it
+    # builds is replaced here with a plain sample-index axis.
+    image = samples[: frames * lines].reshape(frames, lines, order="F") - offset
+    smooth = 1 if lines < 10 else 3
+    erpimage(
+        image, title="Continuous data", smooth=smooth, caxis=2.0 / 3.0, cbar=True, plot_erp=False, target=container
+    )
+
+
+def _draw_spectrum(ax: Any, EEG: dict[str, Any], spectrum_input: np.ndarray, spec_opt: Any, mapnorm: Any) -> None:
+    """Draw the activity power spectrum from raw per-epoch data (spectopo)."""
     spec_options = parse_plot_options_text(spec_opt)
-    flat = trace_2d.reshape(1, -1)
     spectra, freqs, _std = compute_spectra(
-        flat,
-        flat.shape[1],
+        spectrum_input,
+        int(EEG.get("pnts", spectrum_input.shape[1]) or spectrum_input.shape[1]),
         float(EEG.get("srate", 1) or 1),
         winsize=_first_int(spec_options.get("winsize")),
         overlap=_first_int(spec_options.get("overlap")) or 0,
         nfft=_first_int(spec_options.get("nfft")),
+        mapnorm=mapnorm,
     )
-    spec_ax.plot(freqs, spectra[0], color="black")
+    ax.plot(freqs, spectra[0], color="black")
     freqrange = numeric_vector(spec_options.get("freqrange", []))
     if freqrange.size == 2:
-        spec_ax.set_xlim(float(freqrange[0]), float(freqrange[1]))
-    spec_ax.set_xlabel("Frequency (Hz)")
-    spec_ax.set_ylabel("dB")
-    spec_ax.grid(True, alpha=0.25)
-    fig.suptitle(f"pop_prop() - {title} properties", fontweight="bold")
-    fig.tight_layout()
-    return fig
+        ax.set_xlim(float(freqrange[0]), float(freqrange[1]))
+    ax.set_xlabel("Frequency (Hz)")
+    ax.set_ylabel(SPECTRUM_YLABEL)
+    ax.set_title("Activity power spectrum")
+    ax.grid(True, alpha=0.25)
 
 
 def _first_int(value: Any) -> int | None:

--- a/src/eegprep/functions/popfunc/pop_prop.py
+++ b/src/eegprep/functions/popfunc/pop_prop.py
@@ -32,6 +32,19 @@ SPECTRUM_YLABEL = r"Power 10*log$_{10}$($\mu$V$^2$/Hz)"
 CHANNEL_MARKER_SIZE = 50
 EEGLAB_RED = "red"
 COMPONENT_MAP_NUMCONTOUR = 3
+# The ERP-image title is long ("<name> activity (global offset ...)"); a smaller font keeps
+# it inside the panel (EEGLAB shrinks the parenthetical part, pop_prop.m:203).
+ERP_IMAGE_TITLE_FONTSIZE = 11
+# Panel placement for the three-panel figure. hspace leaves room for the ERP-image time
+# axis above the spectrum title; wspace keeps the ERP y-label clear of the scalp map.
+FIGURE_MARGINS = {
+    "left": 0.15,
+    "right": 0.93,
+    "top": 0.92,
+    "bottom": 0.10,
+    "hspace": 0.85,
+    "wspace": 0.42,
+}
 
 
 def pop_prop(
@@ -178,18 +191,26 @@ def _plot_one_property(EEG: dict[str, Any], typecomp: int, index: int, spec_opt:
             # map is not forced to matplotlib's asymmetric [min, max] auto range.
             topoplot(component_map, map_chanlocs, axes=ax, numcontour=COMPONENT_MAP_NUMCONTOUR, maplimits="absmax")
 
-    fig = plt.figure(figsize=(5, 5), layout="constrained")  # EEGLAB uses a 500x500 square
-    top, bottom = fig.subfigures(2, 1, height_ratios=(3, 2))
-    topo_sf, erp_sf = top.subfigures(1, 2, width_ratios=(2, 3))
-    topo_ax = topo_sf.add_subplot(1, 1, 1)
-    spec_ax = bottom.add_subplot(1, 1, 1)
+    # EEGLAB draws a 500x500 window: scalp map upper-left, ERP image + trace upper-right,
+    # power spectrum across the bottom (pop_prop.m:155/176/248). A manual GridSpec with
+    # explicit margins (not constrained layout) lets the ERP image and its trace sit flush,
+    # the way EEGLAB stacks them.
+    fig = plt.figure(figsize=(5, 5))
+    grid = fig.add_gridspec(2, 2, height_ratios=(3, 2), width_ratios=(2, 3), **FIGURE_MARGINS)
+    topo_ax = fig.add_subplot(grid[0, 0])
+    erp_sf = fig.add_subfigure(grid[0, 1])
+    spec_ax = fig.add_subplot(grid[1, :])
 
     draw_topo(topo_ax)
     topo_ax.set_title(basename, fontsize=14)
 
     _draw_erp_image(erp_sf, trace, times, trials, basename, float(EEG.get("srate", 1) or 1), yerplabel)
     _draw_spectrum(spec_ax, EEG, spectrum_input, spec_opt, mapnorm)
-    fig.suptitle(f"pop_prop() - {basename} properties", fontweight="bold")
+    # EEGLAB puts "pop_prop() - <name> properties" in the window title bar, not on the canvas
+    # (pop_prop.m:144).
+    manager = fig.canvas.manager
+    if manager is not None:
+        manager.set_window_title(f"pop_prop() - {basename} properties")
     return fig
 
 
@@ -211,6 +232,7 @@ def _draw_erp_image(
             plot_erp=True,
             target=container,
             yerplabel=yerplabel,
+            title_fontsize=ERP_IMAGE_TITLE_FONTSIZE,
         )
     else:
         _draw_continuous_erp_image(container, trace_2d.reshape(-1), srate)

--- a/src/eegprep/functions/popfunc/pop_prop.py
+++ b/src/eegprep/functions/popfunc/pop_prop.py
@@ -139,26 +139,27 @@ def _plot_one_property(EEG: dict[str, Any], typecomp: int, index: int, spec_opt:
     times = eeg_times_ms(EEG)
     trials = int(EEG.get("trials", 1) or 1)
 
-    fig = plt.figure(figsize=(5, 5), layout="constrained")  # EEGLAB uses a 500x500 square
-    top, bottom = fig.subfigures(2, 1, height_ratios=(3, 2))
-    topo_sf, erp_sf = top.subfigures(1, 2, width_ratios=(2, 3))
-    topo_ax = topo_sf.add_subplot(1, 1, 1)
-    spec_ax = bottom.add_subplot(1, 1, 1)
-
+    # Resolve and validate the trace before creating the figure so a bad index cannot
+    # leak an open figure (EEGLAB validates the range first: pop_prop.m:130).
     if typecomp:
         if index < 1 or index > data.shape[0]:
             raise ValueError("channel index is outside available channels")
         trace = data[index - 1]
         basename = f"Channel {index}"
-        plot_channel_location(
-            topo_ax,
-            chanlocs_as_list(EEG.get("chanlocs", [])),
-            index,
-            markersize=CHANNEL_MARKER_SIZE,
-            color=EEGLAB_RED,
-        )
         spectrum_input = data[index - 1 : index]
         mapnorm = None
+        # EEGLAB pop_prop leaves erpimage's default "ERP" ordinate label for channels
+        # (pop_prop.m:192) and blanks it for components (:200).
+        yerplabel = "ERP"
+
+        def draw_topo(ax: Any) -> None:
+            plot_channel_location(
+                ax,
+                chanlocs_as_list(EEG.get("chanlocs", [])),
+                index,
+                markersize=CHANNEL_MARKER_SIZE,
+                color=EEGLAB_RED,
+            )
     else:
         acts = component_activations(EEG)
         maps, map_chanlocs = component_map_data(EEG)
@@ -166,23 +167,34 @@ def _plot_one_property(EEG: dict[str, Any], typecomp: int, index: int, spec_opt:
             raise ValueError("component index is outside available ICA components")
         trace = acts[index - 1]
         basename = f"IC{index}"
-        # maplimits='absmax' centers the color axis on 0 (EEGLAB topoplot default), so the
-        # map is not forced to matplotlib's asymmetric [min, max] auto range.
-        topoplot(
-            maps[:, index - 1], map_chanlocs, axes=topo_ax, numcontour=COMPONENT_MAP_NUMCONTOUR, maplimits="absmax"
-        )
         spectrum_input = acts[index - 1 : index]
         mapnorm = np.asarray(EEG["icawinv"], dtype=float)[:, index - 1]
+        # EEGLAB blanks the ERP y-label for components (pop_prop.m: 'yerplabel', '').
+        yerplabel = ""
+        component_map = maps[:, index - 1]
+
+        def draw_topo(ax: Any) -> None:
+            # maplimits='absmax' centers the color axis on 0 (EEGLAB topoplot default), so the
+            # map is not forced to matplotlib's asymmetric [min, max] auto range.
+            topoplot(component_map, map_chanlocs, axes=ax, numcontour=COMPONENT_MAP_NUMCONTOUR, maplimits="absmax")
+
+    fig = plt.figure(figsize=(5, 5), layout="constrained")  # EEGLAB uses a 500x500 square
+    top, bottom = fig.subfigures(2, 1, height_ratios=(3, 2))
+    topo_sf, erp_sf = top.subfigures(1, 2, width_ratios=(2, 3))
+    topo_ax = topo_sf.add_subplot(1, 1, 1)
+    spec_ax = bottom.add_subplot(1, 1, 1)
+
+    draw_topo(topo_ax)
     topo_ax.set_title(basename, fontsize=14)
 
-    _draw_erp_image(erp_sf, trace, times, trials, basename, float(EEG.get("srate", 1) or 1))
+    _draw_erp_image(erp_sf, trace, times, trials, basename, float(EEG.get("srate", 1) or 1), yerplabel)
     _draw_spectrum(spec_ax, EEG, spectrum_input, spec_opt, mapnorm)
     fig.suptitle(f"pop_prop() - {basename} properties", fontweight="bold")
     return fig
 
 
 def _draw_erp_image(
-    container: Any, trace: np.ndarray, times: np.ndarray, trials: int, basename: str, srate: float
+    container: Any, trace: np.ndarray, times: np.ndarray, trials: int, basename: str, srate: float, yerplabel: str
 ) -> None:
     """Draw the ERP-image panel, offset-subtracted like EEGLAB nan_mean."""
     trace_2d = trace if trace.ndim == 2 else trace[:, np.newaxis]
@@ -198,6 +210,7 @@ def _draw_erp_image(
             cbar=True,
             plot_erp=True,
             target=container,
+            yerplabel=yerplabel,
         )
     else:
         _draw_continuous_erp_image(container, trace_2d.reshape(-1), srate)

--- a/src/eegprep/functions/popfunc/pop_prop.py
+++ b/src/eegprep/functions/popfunc/pop_prop.py
@@ -26,9 +26,12 @@ from eegprep.functions.sigprocfunc.erpimage import erpimage
 from eegprep.functions.sigprocfunc.spectopo import compute_spectra
 from eegprep.functions.sigprocfunc.topoplot import plot_channel_location, topoplot
 
-# EEGLAB pop_prop() spectrum-axis label and single-channel marker size.
+# EEGLAB pop_prop() spectrum-axis label and 3-contour component map. EEGLAB draws the
+# selected channel marker and its spectrum trace in red.
 SPECTRUM_YLABEL = r"Power 10*log$_{10}$($\mu$V$^2$/Hz)"
-CHANNEL_MARKER_SIZE = 80
+CHANNEL_MARKER_SIZE = 50
+EEGLAB_RED = "red"
+COMPONENT_MAP_NUMCONTOUR = 3
 
 
 def pop_prop(
@@ -147,7 +150,13 @@ def _plot_one_property(EEG: dict[str, Any], typecomp: int, index: int, spec_opt:
             raise ValueError("channel index is outside available channels")
         trace = data[index - 1]
         basename = f"Channel {index}"
-        plot_channel_location(topo_ax, chanlocs_as_list(EEG.get("chanlocs", [])), index, markersize=CHANNEL_MARKER_SIZE)
+        plot_channel_location(
+            topo_ax,
+            chanlocs_as_list(EEG.get("chanlocs", [])),
+            index,
+            markersize=CHANNEL_MARKER_SIZE,
+            color=EEGLAB_RED,
+        )
         spectrum_input = data[index - 1 : index]
         mapnorm = None
     else:
@@ -157,7 +166,7 @@ def _plot_one_property(EEG: dict[str, Any], typecomp: int, index: int, spec_opt:
             raise ValueError("component index is outside available ICA components")
         trace = acts[index - 1]
         basename = f"IC{index}"
-        topoplot(maps[:, index - 1], map_chanlocs, axes=topo_ax, electrodes="off")
+        topoplot(maps[:, index - 1], map_chanlocs, axes=topo_ax, numcontour=COMPONENT_MAP_NUMCONTOUR)
         spectrum_input = acts[index - 1 : index]
         mapnorm = np.asarray(EEG["icawinv"], dtype=float)[:, index - 1]
     topo_ax.set_title(basename, fontsize=14)
@@ -224,7 +233,7 @@ def _draw_spectrum(ax: Any, EEG: dict[str, Any], spectrum_input: np.ndarray, spe
         nfft=_first_int(spec_options.get("nfft")),
         mapnorm=mapnorm,
     )
-    ax.plot(freqs, spectra[0], color="black")
+    ax.plot(freqs, spectra[0], color=EEGLAB_RED)
     freqrange = numeric_vector(spec_options.get("freqrange", []))
     if freqrange.size == 2:
         ax.set_xlim(float(freqrange[0]), float(freqrange[1]))

--- a/src/eegprep/functions/sigprocfunc/erpimage.py
+++ b/src/eegprep/functions/sigprocfunc/erpimage.py
@@ -27,6 +27,7 @@ def erpimage(
     chan_locs: Any = None,
     channel_index: int | None = None,
     target: Any = None,
+    yerplabel: str = "µV",
 ):
     """Plot trials as an EEGLAB-style ERP image plus the average ERP.
 
@@ -38,6 +39,9 @@ def erpimage(
     ``f`` that sets a symmetric color axis of ``+/- f * max(|image|)`` (EEGLAB
     ``erpimage.m`` ``caxfraction``). Pass ``target`` (a Figure or SubFigure) to
     draw the panels into an existing figure instead of opening a new window.
+
+    ``yerplabel`` labels the average-ERP y-axis; EEGLAB passes an empty string
+    for unitless data such as ICA component activations (``'yerplabel', ''``).
     """
     values = np.asarray(data, dtype=float)
     if values.ndim != 2:
@@ -122,7 +126,7 @@ def erpimage(
         if draw_zero:
             erp_ax.axvline(0, color="black", linewidth=_ZERO_LINEWIDTH)
         erp_ax.set_xlabel("Time (ms)")
-        erp_ax.set_ylabel("µV")
+        erp_ax.set_ylabel(yerplabel)
     else:
         image_ax.set_xlabel("Time (ms)")
     if topo_ax is not None:

--- a/src/eegprep/functions/sigprocfunc/erpimage.py
+++ b/src/eegprep/functions/sigprocfunc/erpimage.py
@@ -28,6 +28,7 @@ def erpimage(
     channel_index: int | None = None,
     target: Any = None,
     yerplabel: str = "µV",
+    title_fontsize: float | None = None,
 ):
     """Plot trials as an EEGLAB-style ERP image plus the average ERP.
 
@@ -68,12 +69,14 @@ def erpimage(
     fig_height = 1.2 * sum(height_ratios) + 0.6
     fig = target if target is not None else plt.figure(figsize=(7.5, fig_height))
     # Reserve a narrow colorbar column only when a colorbar is drawn, so cbar=False fills the width.
+    # EEGLAB abuts the ERP trace directly under the image (erpimage.m:2056/2927 share the boundary),
+    # so use no row gap unless a scalp-map row is present (its inset title needs the gap above).
     gs = fig.add_gridspec(
         nrows=len(height_ratios),
         ncols=2 if cbar else 1,
         width_ratios=[20, 1] if cbar else [1],
         height_ratios=height_ratios,
-        hspace=0.15,
+        hspace=0.15 if show_topo else 0.0,
         wspace=0.04,
     )
     row = 0
@@ -105,7 +108,7 @@ def erpimage(
     if limits is not None:
         im.set_clim(*limits)
     image_ax.set_ylabel("Trials")
-    image_ax.set_title(title or "ERP image")
+    image_ax.set_title(title or "ERP image", fontsize=title_fontsize)
     for latency in _numeric_values(vert):
         image_ax.axvline(latency, color="black", linestyle=":", linewidth=0.8)
     if draw_zero:
@@ -127,6 +130,9 @@ def erpimage(
             erp_ax.axvline(0, color="black", linewidth=_ZERO_LINEWIDTH)
         erp_ax.set_xlabel("Time (ms)")
         erp_ax.set_ylabel(yerplabel)
+        # EEGLAB blanks the image's x-tick labels so only the ERP trace carries the time
+        # axis (erpimage.m:2922); this also lets the two panels sit flush.
+        image_ax.tick_params(labelbottom=False)
     else:
         image_ax.set_xlabel("Time (ms)")
     if topo_ax is not None:

--- a/src/eegprep/functions/sigprocfunc/erpimage.py
+++ b/src/eegprep/functions/sigprocfunc/erpimage.py
@@ -7,7 +7,7 @@ from typing import Any
 import matplotlib.pyplot as plt
 import numpy as np
 
-from eegprep.functions.sigprocfunc.topoplot import topo_screen_coords, topoplot
+from eegprep.functions.sigprocfunc.topoplot import plot_channel_location
 
 _ZERO_LINEWIDTH = 2.5  # solid time-zero line, clearly thicker than dotted vert lines (EEGLAB ZEROWIDTH=3.0)
 
@@ -26,12 +26,18 @@ def erpimage(
     vert: Any = None,
     chan_locs: Any = None,
     channel_index: int | None = None,
+    target: Any = None,
 ):
     """Plot trials as an EEGLAB-style ERP image plus the average ERP.
 
     Pass ``chan_locs`` and ``channel_index`` (1-based) to draw a small scalp
     map above the image with the plotted channel marked, matching EEGLAB's
     default ERP-image layout for channels.
+
+    ``caxis`` accepts either ``[lo, hi]`` explicit limits or a single fraction
+    ``f`` that sets a symmetric color axis of ``+/- f * max(|image|)`` (EEGLAB
+    ``erpimage.m`` ``caxfraction``). Pass ``target`` (a Figure or SubFigure) to
+    draw the panels into an existing figure instead of opening a new window.
     """
     values = np.asarray(data, dtype=float)
     if values.ndim != 2:
@@ -56,7 +62,7 @@ def erpimage(
     if plot_erp:
         height_ratios.append(1.0)
     fig_height = 1.2 * sum(height_ratios) + 0.6
-    fig = plt.figure(figsize=(7.5, fig_height))
+    fig = target if target is not None else plt.figure(figsize=(7.5, fig_height))
     # Reserve a narrow colorbar column only when a colorbar is drawn, so cbar=False fills the width.
     gs = fig.add_gridspec(
         nrows=len(height_ratios),
@@ -85,8 +91,12 @@ def erpimage(
     im = image_ax.imshow(image, aspect="auto", origin="lower", extent=extent, cmap="turbo")
     limits = _limits(caxis)
     if limits is None:
-        # EEGLAB erpimage default: color axis symmetric about 0 (erpimage.m).
+        # EEGLAB erpimage default: color axis symmetric about 0, optionally scaled
+        # by a single caxis fraction f -> +/- f * max(|image|) (erpimage.m).
         cmax = float(np.nanmax(np.abs(image))) if image.size else 0.0
+        fraction = _caxis_fraction(caxis)
+        if fraction is not None:
+            cmax *= fraction
         limits = (-cmax, cmax) if np.isfinite(cmax) and cmax > 0 else None
     if limits is not None:
         im.set_clim(*limits)
@@ -116,7 +126,7 @@ def erpimage(
     else:
         image_ax.set_xlabel("Time (ms)")
     if topo_ax is not None:
-        _draw_channel_topo(topo_ax, chan_locs, int(channel_index))
+        plot_channel_location(topo_ax, chan_locs, int(channel_index))
     return fig, image
 
 
@@ -150,6 +160,12 @@ def _limits(value: Any) -> tuple[float, float] | None:
     return float(values[0]), float(values[1])
 
 
+def _caxis_fraction(value: Any) -> float | None:
+    """A single ``caxis`` value is an EEGLAB caxfraction, not explicit limits."""
+    values = _numeric_values(value)
+    return float(values[0]) if values.size == 1 else None
+
+
 def _numeric_values(value: Any) -> np.ndarray:
     if value is None:
         return np.asarray([], dtype=float)
@@ -169,23 +185,6 @@ def _colorbar_ticks(vmin: float, vmax: float) -> tuple[np.ndarray, np.ndarray]:
     else:
         labels = np.round(ticks)
     return ticks, labels
-
-
-def _draw_channel_topo(ax: Any, chan_locs: Any, channel_index: int) -> None:
-    """Render a small scalp map with the plotted channel marked."""
-    topoplot([], chan_locs, style="blank", electrodes="off", axes=ax, title="")
-    if not 1 <= channel_index <= len(chan_locs):
-        return
-    loc = chan_locs[channel_index - 1]
-    try:
-        theta_deg = float(loc.get("theta"))
-        radius_value = float(loc.get("radius"))
-    except (TypeError, ValueError):
-        return
-    if not (np.isfinite(theta_deg) and np.isfinite(radius_value)):
-        return
-    screen_x, screen_y = topo_screen_coords(theta_deg, radius_value)
-    ax.scatter(screen_x, screen_y, c="k", s=24, zorder=6)
 
 
 __all__ = ["erpimage"]

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -84,6 +84,7 @@ def compute_spectra(
     winsize: int | None = None,
     overlap: int = 0,
     nfft: int | None = None,
+    mapnorm: Any = None,
 ) -> tuple[np.ndarray, np.ndarray, None]:
     """Return Welch spectra in dB as ``channels x frequencies``.
 
@@ -91,6 +92,10 @@ def compute_spectra(
     ``frames < sample_count``) is handled per epoch and averaged in linear power
     before the dB conversion, matching EEGLAB ``spectopo``'s ``spectcomp``. 2-D
     concatenated data is unstacked column-major to match MATLAB's ``reshape``.
+
+    ``mapnorm`` (a component scalp-map column) scales the linear power by
+    ``sqrt(mean(mapnorm**4))`` before the dB conversion, so a single component's
+    activation spectrum reflects its projected scalp power (EEGLAB ``spectopo.m``).
     """
     values = np.asarray(data, dtype=float)
     if values.ndim == 3:
@@ -144,6 +149,8 @@ def compute_spectra(
             psd_sum = np.zeros_like(power)
         psd_sum += power
     psd_mean = psd_sum / trials
+    if mapnorm is not None:
+        psd_mean = psd_mean * np.sqrt(np.mean(np.asarray(mapnorm, dtype=float) ** 4))
     spectra = 10.0 * np.log10(np.maximum(psd_mean, np.finfo(float).tiny))
     return spectra, freqs, None
 

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -193,9 +193,9 @@ def plot_spectra(
     spec_ax.set_ylabel(r"Log Power Spectral Density 10*log$_{10}$($\mu$V$^2$/Hz)")
     spec_ax.spines[["top", "right"]].set_visible(False)
 
-    low, high, min_idx, max_idx = _frequency_window(frequency_values, requested_freqs, freqrange)
+    low, high, min_idx, max_idx = frequency_window(frequency_values, requested_freqs, freqrange)
     spec_ax.set_xlim(low, high)
-    y_low, y_high = _spectra_ylim(spectra, min_idx, max_idx)
+    y_low, y_high = spectra_ylim(spectra, min_idx, max_idx)
     if np.isfinite(y_low) and np.isfinite(y_high) and y_high > y_low:
         spec_ax.set_ylim(y_low, y_high)
 
@@ -219,7 +219,7 @@ def plot_spectra(
     return fig
 
 
-def _frequency_window(
+def frequency_window(
     frequency_values: np.ndarray, requested_freqs: np.ndarray, freqrange: Any
 ) -> tuple[float, float, int, int]:
     """Return the (low, high) x-limits and their frequency indices, as EEGLAB does."""
@@ -235,7 +235,7 @@ def _frequency_window(
     return low, high, min_idx, max_idx
 
 
-def _spectra_ylim(spectra: np.ndarray, min_idx: int, max_idx: int) -> tuple[float, float]:
+def spectra_ylim(spectra: np.ndarray, min_idx: int, max_idx: int) -> tuple[float, float]:
     """Data range over the plotted band, expanded by 1/7 each side (EEGLAB convention)."""
     low_i, high_i = sorted((min_idx, max_idx))
     window = spectra[:, low_i : high_i + 1]
@@ -442,10 +442,10 @@ def plot_component_spectra(
     spec_ax.set_xlabel("Frequency (Hz)")
     spec_ax.set_ylabel(r"Log Power Spectral Density 10*log$_{10}$($\mu$V$^2$/Hz)")
     spec_ax.spines[["top", "right"]].set_visible(False)
-    low, high, min_idx, max_idx = _frequency_window(frequency_values, freqs_req, freqrange)
+    low, high, min_idx, max_idx = frequency_window(frequency_values, freqs_req, freqrange)
     spec_ax.set_xlim(low, high)
     stacked = np.vstack([comp_spectra, data_rms[None, :]])
-    y_low, y_high = _spectra_ylim(stacked, min_idx, max_idx)
+    y_low, y_high = spectra_ylim(stacked, min_idx, max_idx)
     if np.isfinite(y_low) and np.isfinite(y_high) and y_high > y_low:
         spec_ax.set_ylim(y_low, y_high)
 

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -273,7 +273,7 @@ def topoplot(datavector, chan_locs, **kwargs):
                 np.linspace(screen_extent[0], screen_extent[1], Zi.shape[1]),
                 np.linspace(screen_extent[2], screen_extent[3], Zi.shape[0]),
             )
-            levels = np.linspace(np.nanmin(Zi), np.nanmax(Zi), 8)[1:-1]
+            levels = _contour_levels(np.nanmin(Zi), np.nanmax(Zi), int(kwargs.get('numcontour', 6)))
             ax.contour(
                 grid_x,
                 grid_y,
@@ -380,7 +380,12 @@ def topo_screen_coords(theta_deg, radius):
     return np.sin(theta) * radius, np.cos(theta) * radius
 
 
-def plot_channel_location(ax, chan_locs, channel_index, *, markersize=24):
+def _contour_levels(zmin, zmax, numcontour):
+    """Return ``numcontour`` interior contour levels between ``zmin`` and ``zmax``."""
+    return np.linspace(zmin, zmax, int(numcontour) + 2)[1:-1]
+
+
+def plot_channel_location(ax, chan_locs, channel_index, *, markersize=24, color="k"):
     """Draw a blank scalp map and mark a single channel's location.
 
     Mirrors EEGLAB's single-channel ``topoplot(..., 'style', 'blank',
@@ -400,7 +405,7 @@ def plot_channel_location(ax, chan_locs, channel_index, *, markersize=24):
     if not (np.isfinite(theta_deg) and np.isfinite(radius_value)):
         return
     screen_x, screen_y = topo_screen_coords(theta_deg, radius_value)
-    ax.scatter(screen_x, screen_y, c="k", s=markersize, zorder=6)
+    ax.scatter(screen_x, screen_y, c=color, s=markersize, zorder=6)
 
 
 def _channel_location_points(chan_locs):

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -380,6 +380,29 @@ def topo_screen_coords(theta_deg, radius):
     return np.sin(theta) * radius, np.cos(theta) * radius
 
 
+def plot_channel_location(ax, chan_locs, channel_index, *, markersize=24):
+    """Draw a blank scalp map and mark a single channel's location.
+
+    Mirrors EEGLAB's single-channel ``topoplot(..., 'style', 'blank',
+    'emarkersize1chan', ...)`` used by the property and ERP-image plots.
+    ``channel_index`` is 1-based; an out-of-range or coordinate-less channel draws
+    just the blank head.
+    """
+    topoplot([], chan_locs, style="blank", electrodes="off", axes=ax, title="")
+    if not 1 <= channel_index <= len(chan_locs):
+        return
+    loc = chan_locs[channel_index - 1]
+    try:
+        theta_deg = float(loc.get("theta"))
+        radius_value = float(loc.get("radius"))
+    except (TypeError, ValueError):
+        return
+    if not (np.isfinite(theta_deg) and np.isfinite(radius_value)):
+        return
+    screen_x, screen_y = topo_screen_coords(theta_deg, radius_value)
+    ax.scatter(screen_x, screen_y, c="k", s=markersize, zorder=6)
+
+
 def _channel_location_points(chan_locs):
     labels = []
     screen_xs = []

--- a/src/eegprep/resources/help/pop_prop.md
+++ b/src/eegprep/resources/help/pop_prop.md
@@ -1,7 +1,7 @@
 # pop_prop
 
-Plots properties of one channel or independent component, including a scalp
-location/map, ERP trace, and spectrum.
+Plots properties of one channel or independent component in a three-panel
+figure: a scalp location/map, an ERP image, and the activity power spectrum.
 
 ```python
 fig, com = pop_prop(EEG, typecomp=1, chanorcomp=1, return_com=True)

--- a/tests/test_erpimage.py
+++ b/tests/test_erpimage.py
@@ -1,0 +1,54 @@
+"""Tests for ``erpimage`` features that ``pop_prop`` composition depends on.
+
+``pop_prop`` reuses ``erpimage`` for its ERP-image panel, which requires two
+EEGLAB-parity behaviours:
+
+* a scalar ``caxis`` fraction sets the colour axis to ``+/- f * max(|data|)``
+  (EEGLAB ``erpimage.m``: symmetric range scaled by ``caxfraction``);
+* ``target`` lets the caller draw the ERP image into an existing figure/subfigure
+  instead of spawning a new window, so it can sit alongside the scalp map and
+  spectrum in one properties figure.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from eegprep.functions.sigprocfunc.erpimage import erpimage
+
+
+def _ramp_trials(points: int = 40, trials: int = 12) -> np.ndarray:
+    rng = np.random.default_rng(0)
+    return rng.standard_normal((points, trials))
+
+
+def test_scalar_caxis_sets_symmetric_fraction_of_max() -> None:
+    data = _ramp_trials()
+    fraction = 2.0 / 3.0
+    fig, image = erpimage(data, caxis=fraction, plot_erp=False, cbar=False)
+
+    magnitude = fraction * float(np.nanmax(np.abs(image)))
+    image_ax = next(ax for ax in fig.axes if ax.get_images())
+    vmin, vmax = image_ax.get_images()[0].get_clim()
+    np.testing.assert_allclose([vmin, vmax], [-magnitude, magnitude], rtol=1e-9)
+    plt.close("all")
+
+
+def test_target_draws_into_existing_subfigure() -> None:
+    data = _ramp_trials()
+    host = plt.figure()
+    target = host.subfigures(2, 1)[0]
+
+    before = set(plt.get_fignums())
+    result_fig, _image = erpimage(data, target=target, cbar=False)
+
+    # No new top-level pyplot window; the panels live inside the caller's figure.
+    assert set(plt.get_fignums()) == before
+    assert result_fig is target
+    assert len(target.axes) >= 2  # ERP image + average ERP
+    plt.close("all")

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -50,8 +50,7 @@ from eegprep.functions.popfunc.pop_spectopo import pop_spectopo
 from eegprep.functions.popfunc.pop_timtopo import pop_timtopo
 from eegprep.functions.popfunc.pop_topoplot import plot_channel_locations, pop_topoplot
 from eegprep.functions.popfunc._chanutils import chanlocs_as_list
-from eegprep.functions.sigprocfunc.erpimage import _draw_channel_topo
-from eegprep.functions.sigprocfunc.topoplot import topoplot
+from eegprep.functions.sigprocfunc.topoplot import plot_channel_location, topoplot
 from eegprep.functions.studyfunc.pop_chanplot import pop_chanplot, pop_chanplot_dialog_spec
 from eegprep.functions.sigprocfunc.coregister import (
     ElectrodeSet,
@@ -1374,7 +1373,7 @@ def test_erpimage_scalp_inset_marks_channel_on_correct_side():
     ]
     for channel_index, on_right in [(2, True), (1, False)]:
         fig, ax = plt.subplots()
-        _draw_channel_topo(ax, chan_locs, channel_index)
+        plot_channel_location(ax, chan_locs, channel_index)
         marker = next(
             np.asarray(c.get_offsets())
             for c in ax.collections

--- a/tests/test_pop_prop.py
+++ b/tests/test_pop_prop.py
@@ -182,6 +182,19 @@ def test_component_map_shows_electrode_markers() -> None:
     plt.close("all")
 
 
+def test_component_map_color_axis_is_symmetric_about_zero() -> None:
+    """The component map uses maplimits='absmax' so 0 maps to the colormap center."""
+    eeg = _epoched_eeg()
+    fig = pop_prop(eeg, 0, 2, plot="off")
+
+    topo_ax = _find_axis(fig, lambda a: bool(a.get_images()) and a.get_title().startswith("IC"))
+    assert topo_ax is not None, "no component scalp-map panel found"
+    vmin, vmax = topo_ax.get_images()[0].get_clim()
+    assert vmax > 0
+    np.testing.assert_allclose(vmin, -vmax, rtol=1e-9)
+    plt.close("all")
+
+
 def test_continuous_data_still_builds_an_erpimage() -> None:
     """Continuous (single-trial) data yields an ERP image, not a bare line plot."""
     eeg = create_test_eeg(n_channels=8, n_samples=4096, srate=128.0, n_trials=1)

--- a/tests/test_pop_prop.py
+++ b/tests/test_pop_prop.py
@@ -1,0 +1,187 @@
+"""Parity tests for the channel/component properties plot ``pop_prop``.
+
+These lock EEGPrep's ``pop_prop`` to EEGLAB ``pop_prop.m``: a square figure with
+three panels -- a scalp map, an ERP image (reusing ``erpimage``), and an activity
+power spectrum. The numeric assertions are closed-form or derived directly from
+EEGLAB source (no live MATLAB), so they run in CI:
+
+* the spectrum is computed from the raw channel/component data, per-epoch averaged
+  (``spectopo``), not from the epoch-flattened ERP-image trace;
+* component spectra are scaled by the component map RMS power ``mapnorm``, which is
+  a constant ``5*log10(mean(map**4))`` dB offset (EEGLAB ``spectopo.m``: linear
+  power is multiplied by ``sqrt(mean(mapnorm.^4))`` before the ``10*log10``);
+* the ERP image is fed the global-offset-subtracted data (EEGLAB ``nan_mean``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+from matplotlib.collections import PathCollection
+import numpy as np
+import pytest
+
+from eegprep.functions.popfunc.plot_utils import component_activations
+from eegprep.functions.popfunc.pop_prop import pop_prop
+from eegprep.functions.sigprocfunc.spectopo import compute_spectra
+from eegprep.functions.sigprocfunc.topoplot import topo_screen_coords
+from tests.fixtures import create_test_eeg, create_test_eeg_with_ica
+
+SPECTRA_ATOL_DB = 1e-6
+
+
+def _epoched_eeg() -> dict[str, Any]:
+    """Small epoched dataset with ICA (>6 trials so EEGLAB uses ei_smooth=3)."""
+    eeg = create_test_eeg_with_ica(n_channels=8, n_samples=128, srate=128.0, n_trials=10)
+    eeg["xmin"] = -0.2
+    eeg["xmax"] = -0.2 + (eeg["pnts"] - 1) / eeg["srate"]
+    eeg["times"] = np.linspace(eeg["xmin"], eeg["xmax"], eeg["pnts"])
+    return eeg
+
+
+def _all_axes(fig: Any) -> list[Any]:
+    """Every axes on a figure, recursing into subfigures."""
+    axes = list(fig.axes)
+    for subfig in getattr(fig, "subfigs", []):
+        axes.extend(_all_axes(subfig))
+    return axes
+
+
+def _find_axis(fig: Any, predicate: Callable[[Any], bool]) -> Any:
+    return next((ax for ax in _all_axes(fig) if predicate(ax)), None)
+
+
+def _spectrum_axis(fig: Any) -> Any:
+    ax = _find_axis(fig, lambda a: a.get_title().strip() == "Activity power spectrum")
+    assert ax is not None, "no 'Activity power spectrum' panel found"
+    return ax
+
+
+def _image_axis(fig: Any) -> Any:
+    ax = _find_axis(fig, lambda a: bool(a.get_images()) and a.get_ylabel() == "Trials")
+    assert ax is not None, "no ERP-image panel (ylabel 'Trials') found"
+    return ax
+
+
+def _topo_axis(fig: Any) -> Any:
+    ax = _find_axis(
+        fig,
+        lambda a: not a.get_images() and any(isinstance(c, PathCollection) for c in a.collections),
+    )
+    assert ax is not None, "no scalp-map panel with a channel marker found"
+    return ax
+
+
+def test_channel_property_has_three_eeglab_panels() -> None:
+    eeg = _epoched_eeg()
+    fig = pop_prop(eeg, 1, 3, plot="off")
+
+    image_ax = _image_axis(fig)
+    assert image_ax.get_ylabel() == "Trials"
+    erp_ax = _find_axis(fig, lambda a: a.get_ylabel() in {"µV", "uV"})
+    assert erp_ax is not None and erp_ax.get_xlabel() == "Time (ms)"
+
+    spec_ax = _spectrum_axis(fig)
+    assert spec_ax.get_xlabel() == "Frequency (Hz)"
+    assert "Power" in spec_ax.get_ylabel()
+    plt.close("all")
+
+
+def test_component_property_titles_match_eeglab() -> None:
+    eeg = _epoched_eeg()
+    fig = pop_prop(eeg, 0, 2, plot="off")
+
+    # EEGLAB puts "<basename> activity (global offset ...)" on the ERP image.
+    assert _find_axis(fig, lambda a: "activity" in a.get_title().lower()) is not None
+    assert _spectrum_axis(fig) is not None
+    plt.close("all")
+
+
+@pytest.mark.parity
+def test_channel_spectrum_uses_raw_per_epoch_data() -> None:
+    """The spectrum comes from spectopo on raw channel data, per-epoch averaged."""
+    eeg = _epoched_eeg()
+    channel = 3
+    fig = pop_prop(eeg, 1, channel, spec_opt=None, plot="off")
+
+    raw = eeg["data"][channel - 1 : channel, :, :]
+    expected, _freqs, _ = compute_spectra(raw, eeg["pnts"], float(eeg["srate"]))
+
+    ydata = np.asarray(_spectrum_axis(fig).lines[0].get_ydata(), dtype=float)
+    np.testing.assert_allclose(ydata, expected[0], atol=SPECTRA_ATOL_DB)
+    plt.close("all")
+
+
+@pytest.mark.parity
+def test_component_spectrum_applies_mapnorm_offset() -> None:
+    """Component spectra are offset by 5*log10(mean(map**4)) dB (spectopo mapnorm)."""
+    eeg = _epoched_eeg()
+    comp = 2
+    fig = pop_prop(eeg, 0, comp, spec_opt=None, plot="off")
+
+    acts = component_activations(eeg)[comp - 1 : comp, :, :]
+    base, _freqs, _ = compute_spectra(acts, eeg["pnts"], float(eeg["srate"]))
+    mapnorm = np.asarray(eeg["icawinv"], dtype=float)[:, comp - 1]
+    expected = base[0] + 5.0 * np.log10(np.mean(mapnorm**4))
+
+    ydata = np.asarray(_spectrum_axis(fig).lines[0].get_ydata(), dtype=float)
+    np.testing.assert_allclose(ydata, expected, atol=SPECTRA_ATOL_DB)
+    plt.close("all")
+
+
+@pytest.mark.parity
+def test_erp_average_uses_global_offset_subtracted_data() -> None:
+    """EEGLAB subtracts the global mean (nan_mean) before drawing the ERP image."""
+    eeg = _epoched_eeg()
+    channel = 4
+    fig = pop_prop(eeg, 1, channel, plot="off")
+
+    trace = eeg["data"][channel - 1]  # (pnts, trials)
+    offset = np.nanmean(trace)
+    expected_erp = np.nanmean(trace - offset, axis=1)
+
+    erp_ax = _find_axis(fig, lambda a: a.get_ylabel() in {"µV", "uV"})
+    assert erp_ax is not None
+    ydata = np.asarray(erp_ax.lines[0].get_ydata(), dtype=float)
+    np.testing.assert_allclose(ydata, expected_erp, atol=1e-9)
+    plt.close("all")
+
+
+def test_channel_topo_marks_only_the_selected_channel() -> None:
+    """The scalp map marks exactly the selected channel (EEGLAB emarkersize1chan)."""
+    eeg = _epoched_eeg()
+    channel = 5
+    fig = pop_prop(eeg, 1, channel, plot="off")
+
+    topo_ax = _topo_axis(fig)
+    markers = [c for c in topo_ax.collections if isinstance(c, PathCollection)]
+    points = np.vstack([np.asarray(m.get_offsets(), dtype=float) for m in markers])
+    assert points.shape[0] == 1, "exactly one channel should be marked"
+
+    loc = eeg["chanlocs"][channel - 1]
+    screen_x, screen_y = topo_screen_coords(float(loc["theta"]), float(loc["radius"]))
+    np.testing.assert_allclose(points[0], [screen_x, screen_y], atol=1e-6)
+    plt.close("all")
+
+
+def test_continuous_data_still_builds_an_erpimage() -> None:
+    """Continuous (single-trial) data yields an ERP image, not a bare line plot."""
+    eeg = create_test_eeg(n_channels=8, n_samples=4096, srate=128.0, n_trials=1)
+    fig = pop_prop(eeg, 1, 2, plot="off")
+
+    image_ax = _image_axis(fig)
+    assert "continu" in image_ax.get_title().lower()
+    assert _spectrum_axis(fig) is not None
+    plt.close("all")
+
+
+def test_return_com_history_command() -> None:
+    eeg = _epoched_eeg()
+    _fig, com = pop_prop(eeg, 1, 5, plot="off", return_com=True)
+    assert com.startswith("pop_prop(EEG, 1, [5]")
+    plt.close("all")

--- a/tests/test_pop_prop.py
+++ b/tests/test_pop_prop.py
@@ -175,6 +175,29 @@ def test_erp_average_y_label_matches_eeglab_pop_prop() -> None:
     plt.close("all")
 
 
+@pytest.mark.parity
+def test_erp_image_and_trace_sit_flush() -> None:
+    """EEGLAB stacks the ERP trace flush under the image, with only the trace carrying the
+    time axis (erpimage.m:2922/2927), and puts the properties label in the window title."""
+    eeg = _epoched_eeg()
+    for typecomp, index in ((1, 3), (0, 2)):
+        fig = pop_prop(eeg, typecomp, index, plot="off")
+        fig.canvas.draw()  # positions are only resolved after a draw
+
+        image_ax = _image_axis(fig)
+        erp_ax = _erp_average_axis(fig)
+        gap = image_ax.get_position().y0 - erp_ax.get_position().y1
+        assert abs(gap) < 1e-3, f"ERP image/trace not flush (gap={gap:.4f}) for typecomp={typecomp}"
+
+        # Only the ERP trace shows the time-axis tick labels (image blanks them).
+        assert not any(t.get_text() and t.get_visible() for t in image_ax.get_xticklabels())
+        assert any(t.get_text() and t.get_visible() for t in erp_ax.get_xticklabels())
+
+        name = f"Channel {index}" if typecomp else f"IC{index}"
+        assert fig.canvas.manager.get_window_title() == f"pop_prop() - {name} properties"
+        plt.close("all")
+
+
 def test_channel_topo_marks_only_the_selected_channel() -> None:
     """The scalp map marks exactly the selected channel (EEGLAB emarkersize1chan)."""
     eeg = _epoched_eeg()

--- a/tests/test_pop_prop.py
+++ b/tests/test_pop_prop.py
@@ -169,6 +169,19 @@ def test_channel_topo_marks_only_the_selected_channel() -> None:
     plt.close("all")
 
 
+def test_component_map_shows_electrode_markers() -> None:
+    """The component scalp map keeps electrode dots on, like EEGLAB pop_prop."""
+    eeg = _epoched_eeg()
+    fig = pop_prop(eeg, 0, 2, plot="off")
+
+    topo_ax = _find_axis(fig, lambda a: bool(a.get_images()) and a.get_title().startswith("IC"))
+    assert topo_ax is not None, "no component scalp-map panel found"
+    dots = [c for c in topo_ax.collections if isinstance(c, PathCollection)]
+    marked = sum(len(np.asarray(c.get_offsets())) for c in dots)
+    assert marked == int(eeg["nbchan"]), "component map should mark every electrode"
+    plt.close("all")
+
+
 def test_continuous_data_still_builds_an_erpimage() -> None:
     """Continuous (single-trial) data yields an ERP image, not a bare line plot."""
     eeg = create_test_eeg(n_channels=8, n_samples=4096, srate=128.0, n_trials=1)

--- a/tests/test_pop_prop.py
+++ b/tests/test_pop_prop.py
@@ -169,6 +169,24 @@ def test_channel_topo_marks_only_the_selected_channel() -> None:
     plt.close("all")
 
 
+@pytest.mark.parity
+def test_spectrum_y_axis_hugs_the_visible_frequency_band() -> None:
+    """The spectrum y-limits track the data within the plotted band, not out-of-view freqs."""
+    eeg = _epoched_eeg()
+    fig = pop_prop(eeg, 0, 2, spec_opt="'freqrange', [2, 50]", plot="off")
+
+    spec_ax = _spectrum_axis(fig)
+    freqs = np.asarray(spec_ax.lines[0].get_xdata(), dtype=float)
+    spectra = np.asarray(spec_ax.lines[0].get_ydata(), dtype=float)
+    band = (freqs >= 2.0) & (freqs <= 50.0)
+    band_lo, band_hi = float(spectra[band].min()), float(spectra[band].max())
+    margin = (band_hi - band_lo) / 7.0
+
+    y_lo, y_hi = spec_ax.get_ylim()
+    np.testing.assert_allclose([y_lo, y_hi], [band_lo - margin, band_hi + margin], rtol=1e-9)
+    plt.close("all")
+
+
 def test_component_map_shows_electrode_markers() -> None:
     """The component scalp map keeps electrode dots on, like EEGLAB pop_prop."""
     eeg = _epoched_eeg()

--- a/tests/test_pop_prop.py
+++ b/tests/test_pop_prop.py
@@ -77,14 +77,22 @@ def _topo_axis(fig: Any) -> Any:
     return ax
 
 
+def _erp_average_axis(fig: Any) -> Any:
+    """The ERP average-trace panel (xlabel 'Time (ms)', no image), below the ERP image."""
+    ax = _find_axis(fig, lambda a: a.get_xlabel() == "Time (ms)" and not a.get_images())
+    assert ax is not None, "no ERP average panel (xlabel 'Time (ms)') found"
+    return ax
+
+
 def test_channel_property_has_three_eeglab_panels() -> None:
     eeg = _epoched_eeg()
     fig = pop_prop(eeg, 1, 3, plot="off")
 
     image_ax = _image_axis(fig)
     assert image_ax.get_ylabel() == "Trials"
-    erp_ax = _find_axis(fig, lambda a: a.get_ylabel() in {"µV", "uV"})
-    assert erp_ax is not None and erp_ax.get_xlabel() == "Time (ms)"
+    # EEGLAB pop_prop labels the channel ERP average "ERP" (erpimage default, pop_prop.m:192).
+    erp_ax = _erp_average_axis(fig)
+    assert erp_ax.get_ylabel() == "ERP"
 
     spec_ax = _spectrum_axis(fig)
     assert spec_ax.get_xlabel() == "Frequency (Hz)"
@@ -145,10 +153,25 @@ def test_erp_average_uses_global_offset_subtracted_data() -> None:
     offset = np.nanmean(trace)
     expected_erp = np.nanmean(trace - offset, axis=1)
 
-    erp_ax = _find_axis(fig, lambda a: a.get_ylabel() in {"µV", "uV"})
-    assert erp_ax is not None
+    erp_ax = _erp_average_axis(fig)
     ydata = np.asarray(erp_ax.lines[0].get_ydata(), dtype=float)
     np.testing.assert_allclose(ydata, expected_erp, atol=1e-9)
+    plt.close("all")
+
+
+@pytest.mark.parity
+def test_erp_average_y_label_matches_eeglab_pop_prop() -> None:
+    """EEGLAB pop_prop labels the channel ERP "ERP" (default) and blanks it for components."""
+    eeg = _epoched_eeg()
+
+    # IC activations are unitless, so EEGLAB passes 'yerplabel', '' (pop_prop.m:200).
+    comp_fig = pop_prop(eeg, 0, 2, plot="off")
+    assert _erp_average_axis(comp_fig).get_ylabel() == ""
+
+    # Channels keep erpimage's default "ERP" label (pop_prop.m:192), so the blanking is
+    # component-specific.
+    chan_fig = pop_prop(eeg, 1, 3, plot="off")
+    assert _erp_average_axis(chan_fig).get_ylabel() == "ERP"
     plt.close("all")
 
 

--- a/tests/test_topoplot.py
+++ b/tests/test_topoplot.py
@@ -19,7 +19,7 @@ import scipy.io
 # Set Agg backend before importing topoplot to avoid display issues
 matplotlib.use('Agg')
 
-from eegprep.functions.sigprocfunc.topoplot import topoplot, griddata_v4, topo_screen_coords
+from eegprep.functions.sigprocfunc.topoplot import _contour_levels, topoplot, griddata_v4, topo_screen_coords
 from eegprep import pop_loadset, pop_saveset
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
 
@@ -114,6 +114,17 @@ class TestGriddataV4(unittest.TestCase):
 
         # Should handle zero distances without crashing
         self.assertEqual(vq.shape, xq_exact.shape)
+
+
+class TestContourLevels(unittest.TestCase):
+    """topoplot draws ``numcontour`` interior contour levels (EEGLAB numcontour)."""
+
+    def test_numcontour_controls_level_count_and_endpoints_excluded(self):
+        # Default of 6 keeps the historical linspace(min, max, 8)[1:-1] behavior.
+        np.testing.assert_allclose(_contour_levels(0.0, 1.0, 6), np.linspace(0.0, 1.0, 8)[1:-1])
+        three = _contour_levels(0.0, 1.0, 3)
+        self.assertEqual(len(three), 3)
+        np.testing.assert_allclose(three, [0.25, 0.5, 0.75])
 
 
 class TestTopoplot(unittest.TestCase):


### PR DESCRIPTION
Bring pop_prop (Plot > Channel/Component properties) to EEGLAB parity: a scalp map, an ERP image reusing erpimage, and the activity power spectrum. Component spectra scale by scalp-map power (mapnorm), the component map centers its color axis on zero and shows electrodes with three contours, the selected channel is marked in red, and the spectrum y-axis hugs the plotted frequency band. Adds parity tests.

Visual parity (EEGLAB on the left): 
<img width="1358" height="612" alt="Screenshot 2026-08-27 at 9 58 09 AM" src="https://github.com/user-attachments/assets/99659951-71e5-49b8-be96-8deeefb70487" />
<img width="1332" height="611" alt="Screenshot 2026-08-27 at 9 57 37 AM" src="https://github.com/user-attachments/assets/3c9efd51-6460-42e2-91f0-270aa8568f2d" />
