### PR TITLE
ci: use opus model alias in claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,7 +66,7 @@ jobs:
             actions: read
 
           claude_args: |
-            --model claude-opus-4-7
+            --model opus
             --max-turns 250
             --allowedTools "Bash(git:*),Bash(./pre-commit.py:*),Bash(uv:*),Bash(gh:*),Bash(python:*)"
             --system-prompt "Always read and follow the guidelines in AGENTS.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. Before submitting any changes: 1) Run ./pre-commit.py --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."
@@ -162,7 +162,7 @@ jobs:
 
               Always produce output — either a PR or an analysis comment. Never silently exit.
             claude_args: |
-              --model claude-opus-4-7
+              --model opus
               --max-turns 250
               --permission-mode acceptEdits
               --allowedTools "Bash(git:*),Bash(./pre-commit.py:*),Bash(uv:*),Bash(gh:*),Bash(python:*)"
@@ -211,6 +211,6 @@ jobs:
             6. Commit and push changes to the PR branch
             7. Post a comment summarizing what was changed, prefixed with "🤖 Autofix:"
           claude_args: |
-            --model claude-opus-4-7
+            --model opus
             --max-turns 100
             --allowedTools "Bash(git:*),Bash(./pre-commit.py:*),Bash(uv:*),Bash(gh:*),Bash(python:*)"


### PR DESCRIPTION
The Claude Code workflow pinned --model claude-opus-4-7. As of 2026-08-27 that model id is rejected: the action authenticates fine (app token obtained, write permission confirmed) but the CLI exits after 256ms with num_turns 1, total_cost_usd 0 and empty modelUsage. The same workflow and secret succeeded on 2026-08-25, so the OAuth token is not the problem.

This switches the three claude_args blocks to the floating --model opus alias, matching claude-code-review.yml, so the workflow does not break again when a pinned id is retired.

Verification: after merge, comment @claude on an open PR and confirm the run reaches turns greater than 1 with non-zero cost.