### PR TITLE
ci: temporarily show full claude output

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,6 +60,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'
+          # TEMPORARY: surfaces the suppressed CLI error while the bot fails at
+          # startup. Revert once the cause is identified.
+          show_full_output: true
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
The Claude Code job has been failing since 2026-08-27. It authenticates fine (app token obtained, write permission confirmed) and now resolves a valid current model, but the CLI exits 241ms after init with num_turns 1, total_cost_usd 0 and empty modelUsage. The error text is suppressed by the action.

This enables show_full_output on the tag job so one triggered run reveals the message. It is temporary and will be reverted immediately after, in the same session.

Note this prints Claude's output publicly for the duration.