### PR TITLE
ci: revert temporary full claude output

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,9 +60,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'
-          # TEMPORARY: surfaces the suppressed CLI error while the bot fails at
-          # startup. Revert once the cause is identified.
-          show_full_output: true
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
Reverts the temporary show_full_output diagnostic.

It did its job: the run returns 403 oauth_org_not_allowed, "Your organization has disabled Claude subscription access for Claude Code. Use an Anthropic API key instead, or ask your admin to enable access." The OAuth token is not expired; org policy blocks subscription auth for Claude Code.