### PR TITLE
Write epoch.event indices 1-based on disk

### DIFF
--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -96,6 +96,8 @@ Practical rules:
 * ``chanlocs[i]["urchan"]``, ``event[i]["urevent"]``, ``epoch[k]["event"]``, and
   ``epoch[k]["eventurevent"]`` follow the same rule: zero-based in memory,
   one-based on disk.
+* Single-trial datasets have no ``epoch`` structure: ``eeg_checkset`` empties
+  it and removes ``event[i]["epoch"]``, as EEGLAB does.
 
 For epoched data, ``EEG["data"][:, :, trial_index]`` is zero-based Python
 indexing. User-facing epoch and component selectors in GUI dialogs use

--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -93,6 +93,9 @@ Practical rules:
   read and reused later.
 * ``icachansind`` is normalized to zero-based integer indices after loading a
   MATLAB ``.set`` file, then converted back to one-based values when saving.
+* ``chanlocs[i]["urchan"]``, ``event[i]["urevent"]``, ``epoch[k]["event"]``, and
+  ``epoch[k]["eventurevent"]`` follow the same rule: zero-based in memory,
+  one-based on disk.
 
 For epoched data, ``EEG["data"][:, :, trial_index]`` is zero-based Python
 indexing. User-facing epoch and component selectors in GUI dialogs use

--- a/src/eegprep/functions/adminfunc/eeg_checkset.py
+++ b/src/eegprep/functions/adminfunc/eeg_checkset.py
@@ -410,6 +410,13 @@ def eeg_checkset(EEG, *checks, load_data=True):
     except exception_type as e:
         logger.warning(f"Could not build epoch structure: {e}")
 
+    # Single-trial data carries no epoch structure and no event.epoch field
+    # (eeg_checkset.m, "check if only one epoch").
+    if int(EEG.get('trials', 1) or 1) == 1:
+        for ev in EEG['event']:
+            ev.pop('epoch', None)
+        EEG['epoch'] = np.array([], dtype=object)
+
     # check if EEG['data'] is 3D
     if 'data' in EEG and EEG['data'].ndim == 3:
         if EEG['data'].shape[2] == 1:

--- a/src/eegprep/functions/popfunc/pop_loadset.py
+++ b/src/eegprep/functions/popfunc/pop_loadset.py
@@ -111,20 +111,22 @@ def pop_loadset(file_path=None, *args, loadmode="all", memmap=None, **kwargs):
     if not loaded_with_h5:
         _load_sidecar_data(EEG, Path(file_path), use_memmap=use_memmap)
 
+    # Convert 1-based MATLAB urchan/urevent to 0-based before eeg_checkset, which
+    # copies event.urevent into epoch.eventurevent.
+    chanlocs = EEG.get('chanlocs', default_empty)
+    if len(chanlocs) > 0 and 'urchan' in chanlocs[0]:
+        for i in range(len(chanlocs)):
+            chanlocs[i]['urchan'] = chanlocs[i]['urchan'] - 1
+
+    event = EEG.get('event', default_empty)
+    if len(event) > 0 and 'urevent' in event[0]:
+        for i in range(len(event)):
+            if 'urevent' in event[i] and event[i]['urevent'] is not None:
+                event[i]['urevent'] = event[i]['urevent'] - 1
+
     EEG = eeg_checkset(EEG)
     EEG.pop("changes_not_saved", None)
     EEG["saved"] = "justloaded"
-
-    # check if EEG['urchan'] is 0-based
-    if len(EEG['chanlocs']) > 0 and 'urchan' in EEG['chanlocs'][0]:
-        for i in range(len(EEG['chanlocs'])):
-            EEG['chanlocs'][i]['urchan'] = EEG['chanlocs'][i]['urchan'] - 1
-
-    # check if EEG['chanlocs'][i]['urevent'] is 0-based
-    if len(EEG['event']) > 0 and 'urevent' in EEG['event'][0]:
-        for i in range(len(EEG['event'])):
-            if 'urevent' in EEG['event'][i] and EEG['event'][i]['urevent'] is not None:
-                EEG['event'][i]['urevent'] = EEG['event'][i]['urevent'] - 1
 
     return EEG
 

--- a/src/eegprep/functions/popfunc/pop_loadset.py
+++ b/src/eegprep/functions/popfunc/pop_loadset.py
@@ -112,7 +112,12 @@ def pop_loadset(file_path=None, *args, loadmode="all", memmap=None, **kwargs):
         _load_sidecar_data(EEG, Path(file_path), use_memmap=use_memmap)
 
     # Convert 1-based MATLAB urchan/urevent to 0-based before eeg_checkset, which
-    # copies event.urevent into epoch.eventurevent.
+    # copies event.urevent into epoch.eventurevent.  scipy's squeeze_me returns a
+    # bare dict for a 1x1 struct array, so wrap it in a list first.
+    for key in ('chanlocs', 'event'):
+        if isinstance(EEG.get(key), dict):
+            EEG[key] = [EEG[key]]
+
     chanlocs = EEG.get('chanlocs', default_empty)
     if len(chanlocs) > 0 and 'urchan' in chanlocs[0]:
         for i in range(len(chanlocs)):

--- a/src/eegprep/functions/popfunc/pop_saveset.py
+++ b/src/eegprep/functions/popfunc/pop_saveset.py
@@ -93,15 +93,22 @@ def _matlab_empty_or_copy(EEG, key):
     """Like ``_matlab_empty_if_missing`` but deep-copies struct-array fields.
 
     Saving applies in-place 1-based offsets and latency coercion to the
-    MATLAB-facing structures; copying first keeps the caller's chanlocs/event
-    dicts (0-based urchan/urevent, untouched latencies) intact.  ``chanlocs``
-    and ``event`` can be Python lists or NumPy object arrays of dicts, so both
-    are deep-copied.
+    MATLAB-facing structures; copying first keeps the caller's chanlocs/event/
+    epoch dicts (0-based urchan/urevent/event indices, untouched latencies)
+    intact.  These fields can be Python lists or NumPy object arrays of dicts,
+    so both are deep-copied.
     """
     value = _matlab_empty_if_missing(EEG, key)
     if isinstance(value, list) or (isinstance(value, np.ndarray) and value.dtype == object):
         return copy.deepcopy(value)
     return value
+
+
+def _one_based(value):
+    """Shift 0-based index value(s) to MATLAB 1-based; accepts a scalar, list, or array."""
+    if isinstance(value, (list, np.ndarray)):
+        return [v + 1 for v in value]
+    return value + 1
 
 
 def _matlab_empty_struct_if_missing(EEG, key):
@@ -406,7 +413,7 @@ def pop_saveset(EEG, file_name=None, *args, **kwargs):
         'event': _matlab_empty_or_copy(EEG, 'event'),
         'urevent': _matlab_empty_if_missing(EEG, 'urevent'),
         'eventdescription': _matlab_empty_if_missing(EEG, 'eventdescription'),
-        'epoch': _matlab_empty_if_missing(EEG, 'epoch'),
+        'epoch': _matlab_empty_or_copy(EEG, 'epoch'),
         'epochdescription': _matlab_empty_if_missing(EEG, 'epochdescription'),
         'reject': _matlab_empty_if_missing(EEG, 'reject'),
         'stats': _matlab_empty_if_missing(EEG, 'stats'),
@@ -437,6 +444,12 @@ def pop_saveset(EEG, file_name=None, *args, **kwargs):
     if len(eeglab_dict['event']) > 0 and 'urevent' in eeglab_dict['event'][0]:
         for i in range(len(eeglab_dict['event'])):
             eeglab_dict['event'][i]['urevent'] = eeglab_dict['event'][i]['urevent'] + 1
+
+    # epoch.event / epoch.eventurevent index EEG.event / EEG.urevent: 0-based in memory
+    for ep in eeglab_dict['epoch']:
+        for key in ('event', 'eventurevent'):
+            if key in ep:
+                ep[key] = _one_based(ep[key])
 
     # Serialize chanlocs through the single canonical chanloc converter so the
     # primary channel struct uses the same schema as chaninfo.removedchans.

--- a/tests/test_eeg_checkset.py
+++ b/tests/test_eeg_checkset.py
@@ -13,6 +13,7 @@ import logging
 # Add src to path for imports
 sys.path.insert(0, 'src')
 from eegprep.functions.adminfunc.eeg_checkset import eeg_checkset, strict_mode
+from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.utils.testing import DebuggableTestCase
 
 
@@ -428,6 +429,21 @@ class TestEegChecksetDataSqueezing(DebuggableTestCase):
         # Should remain 2D
         self.assertEqual(result['data'].ndim, 2)
         self.assertEqual(result['data'].shape, (32, 1000))
+
+    def test_single_trial_clears_epoch_and_event_epoch_field(self):
+        """Like eeg_checkset.m, trials == 1 drops the epoch struct and event.epoch."""
+        eeg = pop_loadset('sample_data/eeglab_data_epochs_ica.set')
+        eeg['data'] = eeg['data'][:, :, :1]
+        eeg['trials'] = 1
+        eeg['event'] = [ev for ev in eeg['event'] if ev['epoch'] == 1]
+        eeg['epoch'] = eeg['epoch'][:1]
+        self.assertEqual(len(eeg['epoch']), 1)
+
+        result = eeg_checkset(eeg)
+
+        self.assertEqual(len(result['epoch']), 0)
+        self.assertEqual(len(result['event']), 3)
+        self.assertFalse(any('epoch' in ev for ev in result['event']))
 
 
 class TestEegChecksetICAActivations(DebuggableTestCase):

--- a/tests/test_pop_loadset.py
+++ b/tests/test_pop_loadset.py
@@ -4,6 +4,8 @@ import pytest
 
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.popfunc.pop_loadset_h5 import pop_loadset_h5
+from eegprep.functions.popfunc.pop_saveset import pop_saveset
+from eegprep.functions.popfunc.pop_select import pop_select
 
 
 def test_pop_loadset_marks_loaded_dataset_justloaded():
@@ -43,6 +45,22 @@ def test_pop_loadset_epoch_eventurevent_is_zero_based_like_event_urevent(path):
     assert list(eeg["epoch"][0]["eventurevent"]) == [0, 1, 2]
     for ep in eeg["epoch"]:
         assert list(ep["eventurevent"]) == [eeg["event"][i]["urevent"] for i in ep["event"]]
+
+
+def test_pop_loadset_single_event_and_single_channel_set(tmp_path):
+    # A 1x1 MATLAB struct array is read by scipy as a bare dict, not a list.
+    eeg = pop_loadset("sample_data/eeglab_data.set")
+    eeg = pop_select(eeg, channel=[0])
+    eeg["event"] = [dict(eeg["event"][0])]
+    out = str(tmp_path / "one_event_one_channel.set")
+    pop_saveset(eeg, out)
+
+    reloaded = pop_loadset(out)
+
+    assert len(reloaded["chanlocs"]) == 1
+    assert reloaded["chanlocs"][0]["urchan"] == eeg["chanlocs"][0]["urchan"]
+    assert len(reloaded["event"]) == 1
+    assert reloaded["event"][0]["urevent"] == eeg["event"][0]["urevent"]
 
 
 def test_pop_loadset_hdf5_fallback_does_not_subtract_icachansind_twice():

--- a/tests/test_pop_loadset.py
+++ b/tests/test_pop_loadset.py
@@ -33,6 +33,18 @@ def test_pop_loadset_normalizes_nonempty_icachansind_to_zero_based_integers():
     np.testing.assert_array_equal(eeg["icachansind"][:5], np.array([0, 1, 2, 3, 4]))
 
 
+@pytest.mark.parametrize(
+    "path", ["sample_data/eeglab_data_epochs_ica.set", "sample_data/eeglab_data_epochs_ica_hdf5.set"]
+)
+def test_pop_loadset_epoch_eventurevent_is_zero_based_like_event_urevent(path):
+    eeg = pop_loadset(path)
+
+    assert list(eeg["epoch"][0]["event"]) == [0, 1, 2]
+    assert list(eeg["epoch"][0]["eventurevent"]) == [0, 1, 2]
+    for ep in eeg["epoch"]:
+        assert list(ep["eventurevent"]) == [eeg["event"][i]["urevent"] for i in ep["event"]]
+
+
 def test_pop_loadset_hdf5_fallback_does_not_subtract_icachansind_twice():
     eeg = pop_loadset("sample_data/eeglab_data_epochs_ica_hdf5.set")
 

--- a/tests/test_pop_saveset.py
+++ b/tests/test_pop_saveset.py
@@ -68,6 +68,29 @@ class TestPopSaveset(unittest.TestCase):
         self.assertEqual(urchan_after, urchan_before)  # still 0-based in memory
         self.assertEqual(urevent_after, urevent_before)
         np.testing.assert_array_equal(latency_after, latency_before)
+
+    def test_saveset_writes_epoch_event_indices_one_based(self):
+        src = os.path.join(local_url, 'eeglab_data_epochs_ica.set')
+        EEG = pop_loadset(src)
+        epoch_before = [(list(ep['event']), list(ep['eventurevent'])) for ep in EEG['epoch']]
+        self.assertEqual(epoch_before[0], ([0, 1, 2], [0, 1, 2]))  # 0-based in memory
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, 'epochs.set')
+            pop_saveset(EEG, out)
+
+            raw_src = scipy.io.loadmat(src, squeeze_me=True, struct_as_record=False)['EEG'].epoch[0]
+            raw_out = scipy.io.loadmat(out, squeeze_me=True, struct_as_record=False)['epoch'][0]
+            np.testing.assert_array_equal(raw_src.event, [1, 2, 3])
+            np.testing.assert_array_equal(raw_out.event, raw_src.event)  # 1-based on disk
+            np.testing.assert_array_equal(raw_out.eventurevent, [1, 2, 3])
+
+            reloaded = pop_loadset(out)
+
+        epoch_after = [(list(ep['event']), list(ep['eventurevent'])) for ep in EEG['epoch']]
+        self.assertEqual(epoch_after, epoch_before)  # caller's dict not mutated
+        epoch_reloaded = [(list(ep['event']), list(ep['eventurevent'])) for ep in reloaded['epoch']]
+        self.assertEqual(epoch_reloaded, epoch_before)  # round trip
         # """Test basic resampling functionality with different engines"""
         # # Apply resampling with different engines
         # EEG_python = pop_resample(self.EEG.copy(), self.new_freq, engine='scipy')


### PR DESCRIPTION
🤖 Write `epoch[k].event` / `epoch[k].eventurevent` 1-based on disk, keep them 0-based in memory.

## Problem

EEGPrep's convention for index-valued fields is 0-based in memory, 1-based on disk. `pop_saveset` applies this to `icachansind`, `chanlocs[i].urchan`, and `event[i].urevent`, but not to `epoch[k].event` (indices into `EEG.event`) or `epoch[k].eventurevent`.

Verified with `sample_data/eeglab_data_epochs_ica.set`: `pop_loadset` then `pop_saveset` to a new file, read raw with `scipy.io.loadmat(..., squeeze_me=True, struct_as_record=False)`:

- original MATLAB file: `epoch(1).event = [1 2 3]`
- EEGPrep-saved file: `epoch(1).event = [0 1 2]`

A second, related inconsistency: `pop_loadset` called `eeg_checkset` (which copies `event[i].urevent` into `epoch[k].eventurevent`) *before* subtracting 1 from `event[i].urevent`. In memory this gave `epoch[0].eventurevent == [1, 2, 3]` while `event[0..2].urevent == [0, 1, 2]`. The on-disk `eventurevent` only looked right by accident of that ordering.

## Fix

- `pop_loadset.py`: move the urchan/urevent 1-to-0 conversion ahead of the `eeg_checkset` call, so `epoch[k].eventurevent` is derived from already 0-based `urevent`. Applies to both the scipy (v7) and HDF5 (v7.3) load paths, since both go through this call. `pop_loadset_h5.py` itself never rebased urevent, so it needed no change.
- `pop_saveset.py`: deep-copy `epoch` (same `_matlab_empty_or_copy` pattern as `chanlocs`/`event`) and add 1 to `epoch[k].event` and `epoch[k].eventurevent` before `savemat`. Handles scalar, list, and array values and empty epochs. `pop_saveset` has only one writer (`scipy.io.savemat`, MATLAB v7); there is no HDF5 save path.
- `docs/source/user_guide/concepts.rst`: one bullet stating that `urchan`, `urevent`, `epoch[k].event`, and `epoch[k].eventurevent` follow the 0-based-in-memory / 1-based-on-disk rule.

In-memory values stay 0-based; the caller's `EEG` dict is not mutated by saving.

## Verification

New tests (fail on `origin/develop`, pass on this branch):

- `tests/test_pop_saveset.py::TestPopSaveset::test_saveset_writes_epoch_event_indices_one_based` — raw scipy read of the saved file shows `epoch[0].event == [1, 2, 3]` (identical to the original file) and `epoch[0].eventurevent == [1, 2, 3]`; caller's epoch records unchanged after save; load -> save -> reload gives identical `epoch` event/eventurevent records.
- `tests/test_pop_loadset.py::test_pop_loadset_epoch_eventurevent_is_zero_based_like_event_urevent` (parametrized over the v7 and HDF5 sample files) — `epoch[k].eventurevent == [event[i].urevent for i in epoch[k].event]` for every epoch.

```
EEGPREP_SKIP_MATLAB=1 QT_QPA_PLATFORM=offscreen uv run pytest tests/test_pop_saveset.py tests/test_pop_loadset.py tests/test_pop_loadset_h5.py tests/test_eeg_checkset.py tests/test_pop_epoch.py -q
# 98 passed, 9 skipped (MATLAB not available)

EEGPREP_SKIP_MATLAB=1 QT_QPA_PLATFORM=offscreen uv run pytest tests/test_console_workspace.py tests/test_pop_select.py -q
# 154 passed, 4 skipped (MATLAB not available)

ruff check / ruff format --check on the changed files: clean
```

Not verified: reading the EEGPrep-written file back in MATLAB (MATLAB not run for this change).
