### PR TITLE
Fix events.tsv onset off by one in bids_preproc

### DIFF
--- a/src/eegprep/plugins/EEG_BIDS/bids_preproc.py
+++ b/src/eegprep/plugins/EEG_BIDS/bids_preproc.py
@@ -85,6 +85,29 @@ def _copy_misc_root_files(root: str, dst: str, exclude: List[str]) -> None:
             logger.error(f"Failed to copy {srcpath} to {dstpath}: {e}")
 
 
+def _write_events_tsv(EEG: dict, fpath: str) -> None:
+    """Write EEG['event'] to a BIDS events.tsv (onset/duration in seconds).
+
+    Event latencies are 1-based samples (latency 1 = first sample) and may be
+    fractional; durations are in samples. For epoched data, latencies are
+    concatenated across epochs, so onsets are relative to the start of the
+    concatenated epoched array.
+    """
+    have_hed_column = EEG['etc'].get('event_column', None) == 'HED'
+    columns = ['onset', 'duration', 'trial_type'] + (['HED'] if have_hed_column else [])
+    srate = EEG['srate']
+    with open(fpath, 'w') as fp:
+        print('\t'.join(columns), file=fp)
+        for e in EEG['event']:
+            ev_type = e['type']
+            ev_time = (e['latency'] - 1) / srate
+            ev_dur = (e.get('duration') or 0.0) / srate
+            if np.isnan(ev_dur):
+                ev_dur = 0.0
+            row = [ev_time, ev_dur, ev_type] + ([ev_type] if have_hed_column else [])
+            print('\t'.join(str(r) for r in row), file=fp)
+
+
 def _legacy_override(new_and_name: Tuple[Any, str], old_and_name: Tuple[Any, str], default: Any):
     """Handle overrides with values from legacy parameters and a default if both the new and legacy parameter are None."""
     new, new_name = new_and_name
@@ -1011,23 +1034,7 @@ def bids_preproc(
                 # rewrite the events file
                 if len(EEG['event']):
                     fpath_events = gen_derived_fpath(fn, outputdir=OutputDir, suffix='events', extension='.tsv')
-                    have_hed_column = EEG['etc'].get('event_column', None) == 'HED'
-                    columns = ['onset', 'duration', 'trial_type'] + (['HED'] if have_hed_column else [])
-                    with open(fpath_events, 'w') as fp:
-                        print('\t'.join(columns), file=fp)
-                        times, srate = EEG['times'], EEG['srate']
-                        for e in EEG['event']:
-                            ev_type = e['type']
-                            try:
-                                ev_time = times[e['latency']] / 1000.0  # in ms
-                            except IndexError:
-                                logger.error(f'out-of-bounds event {ev_type} at lat {e["latency"]}; ignoring')
-                                continue
-                            ev_dur = e.get('duration', 0.0) / srate
-                            if np.isnan(ev_dur):
-                                ev_dur = 0.0
-                            row = [ev_time, ev_dur, ev_type] + ([ev_type] if have_hed_column else [])
-                            print('\t'.join(str(r) for r in row), file=fp)
+                    _write_events_tsv(EEG, fpath_events)
 
                 # rewrite the channels file
                 fpath_channels = gen_derived_fpath(fn, outputdir=OutputDir, suffix='channels', extension='.tsv')

--- a/tests/test_bids_preproc.py
+++ b/tests/test_bids_preproc.py
@@ -4,13 +4,18 @@ Test suite for bids_preproc.py
 
 import logging
 import os
+import shutil
 import socket
+import tempfile
 import unittest
 
 import numpy as np
 
+from eegprep.functions.popfunc.pop_loadset import pop_loadset
+from eegprep.plugins.EEG_BIDS.bids_preproc import _write_events_tsv
 from eegprep.plugins.EEG_BIDS.coords import coords_to_mm
 from eegprep.utils.testing import DebuggableTestCase
+from tests.fixtures import SAMPLE_DATASET_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -231,6 +236,52 @@ class TestBidsPreproc(DebuggableTestCase):
                 EpochBaseline=[None, 0],
                 MinimizeDiskUsage=False,
             )
+
+
+class TestWriteEventsTsv(unittest.TestCase):
+    """events.tsv onsets use 1-based, possibly fractional, sample latencies."""
+
+    def setUp(self):
+        self.EEG = pop_loadset(str(SAMPLE_DATASET_PATH))
+        self.tmpdir = tempfile.mkdtemp()
+        self.fpath = os.path.join(self.tmpdir, 'events.tsv')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _read_rows(self):
+        with open(self.fpath) as fp:
+            header = fp.readline().rstrip('\n').split('\t')
+            rows = [line.rstrip('\n').split('\t') for line in fp]
+        return header, rows
+
+    def test_fractional_latencies_written_without_drops(self):
+        events, srate = self.EEG['event'], self.EEG['srate']
+        # sample data has fractional latencies, which previously raised IndexError
+        self.assertNotEqual(events[0]['latency'], int(events[0]['latency']))
+
+        _write_events_tsv(self.EEG, self.fpath)
+
+        header, rows = self._read_rows()
+        self.assertEqual(header, ['onset', 'duration', 'trial_type'])
+        self.assertEqual(len(rows), len(events))
+        for row, e in zip(rows, events):
+            self.assertAlmostEqual(float(row[0]), (e['latency'] - 1) / srate, places=12)
+            self.assertEqual(float(row[1]), 0.0)
+            self.assertEqual(row[2], e['type'])
+
+    def test_first_and_last_sample_onsets(self):
+        srate, pnts = self.EEG['srate'], self.EEG['pnts']
+        first, last = dict(self.EEG['event'][0]), dict(self.EEG['event'][1])
+        first['latency'], last['latency'] = 1.0, float(pnts)
+        self.EEG['event'] = [first, last]
+
+        _write_events_tsv(self.EEG, self.fpath)
+
+        _, rows = self._read_rows()
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(float(rows[0][0]), 0.0)
+        self.assertAlmostEqual(float(rows[1][0]), (pnts - 1) / srate, places=12)
 
 
 class TestCoordsToMm(unittest.TestCase):


### PR DESCRIPTION
🤖 

## Problem

`bids_preproc` rewrote the derivative `events.tsv` with `ev_time = EEG['times'][e['latency']] / 1000.0`. Event latencies are 1-based samples (latency 1.0 = first sample, EEGLAB convention) while `EEG['times']` is a 0-based array, so:

- Every onset was one sample late: latency 1 mapped to `times[1]` = 7.8125 ms at 128 Hz instead of 0.
- An event at the last sample (`latency == pnts`) raised `IndexError` and was dropped.
- Any fractional latency (e.g. 129.00875 in `sample_data/eeglab_data.set`, or anything after resampling) raised `IndexError` and was dropped. On `eeglab_data.set` the old code kept 0 of 154 events.

The dropped events also masked a second failure: `pop_loadset` yields `duration=None` for empty MATLAB fields, so `e.get('duration', 0.0) / srate` would have raised `TypeError` once an event got past the onset lookup.

## Fix

- Onset is now `(latency - 1) / srate`, the same conversion already used by `plugins/EEG_BIDS/pop_exportbids.py`. No `times[...]` lookup, so no `IndexError` and no dropped events. Duration stays `duration / srate` (EEGLAB stores duration in samples); `None` is treated as 0.
- The writer is extracted into a top-level `_write_events_tsv(EEG, fpath)` so it can be tested on real data without running the pipeline. `grep -rn "times\[" src/eegprep/plugins/EEG_BIDS/` shows this was the only such lookup under `EEG_BIDS`.

## Epoched data

`bids_preproc` writes `events.tsv` after the optional `pop_epoch` stage, so epoched datasets are exported too. `pop_epoch` produces 1-based latencies concatenated across epochs (`... + 1 + pnts * epoch_index`), so `(latency - 1) / srate` gives the onset relative to the start of the concatenated epoched array, consistent with `pop_exportbids`. No behaviour beyond that is introduced; the helper docstring states this.

## Verification

```
EEGPREP_SKIP_MATLAB=1 python -m pytest tests/test_bids_preproc.py tests/test_bids_preproc_old.py \
    tests/test_bids_gen_derived_fpath.py tests/test_bids_load_frombids_helpers.py -q
# 8 passed, 2 skipped (MATLAB end-to-end), 3 subtests passed
ruff check / ruff format --check on the two changed files: clean
```

New `TestWriteEventsTsv` (2 tests, real `sample_data/eeglab_data.set`, no torch/MATLAB): all 154 events written with onset `(latency-1)/srate` (fractional latencies included, duration 0, type preserved), and latency 1 / latency `pnts` map to 0.0 s and `(pnts-1)/srate`.
