### PR TITLE
Make raw-file BIDS event latencies 1-based

### DIFF
--- a/src/eegprep/plugins/EEG_BIDS/raw.py
+++ b/src/eegprep/plugins/EEG_BIDS/raw.py
@@ -326,7 +326,8 @@ def _read_neo_events(io: Any, ext: str, times_sec: np.ndarray, numeric_null: Any
             f"Unsupported file format for event extraction: {ext}. Supported formats are .edf, .bdf, .vhdr."
         )
 
-    event_latencies = np.searchsorted(times_sec, all_times)
+    # 1-based sample indices (EEGLAB convention), same rounding as the events.tsv path
+    event_latencies = np.searchsorted(times_sec, all_times) + 1
     event_durations = np.array(all_durations, dtype=float)
     urevents = np.arange(len(all_times))
     return np.array(

--- a/tests/test_bids_load_frombids_helpers.py
+++ b/tests/test_bids_load_frombids_helpers.py
@@ -1,8 +1,97 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import numpy as np
+import pyedflib
+
+EDF_SRATE = 100
+EDF_SECONDS = 10
+# annotation onsets in seconds -> expected 1-based latencies 1, 101, 1000 (last sample)
+EDF_ANNOTATIONS = [(0.0, "A"), (1.0, "B"), (9.99, "C")]
+
+
+def _write_edf_bids_dataset(root: Path) -> Path:
+    """Write a minimal EDF+ BIDS dataset with annotations and an events.tsv sidecar."""
+    eeg_dir = root / "sub-01" / "eeg"
+    eeg_dir.mkdir(parents=True)
+    (root / "dataset_description.json").write_text(json.dumps({"Name": "edf", "BIDSVersion": "1.8.0"}))
+    edf_path = eeg_dir / "sub-01_task-x_eeg.edf"
+    t = np.arange(EDF_SRATE * EDF_SECONDS) / EDF_SRATE
+    signals = [50 * np.sin(2 * np.pi * 10 * t), 50 * np.cos(2 * np.pi * 10 * t)]
+    writer = pyedflib.EdfWriter(str(edf_path), len(signals), file_type=pyedflib.FILETYPE_EDFPLUS)
+    writer.setSignalHeaders(
+        [
+            {
+                "label": f"C{index}",
+                "dimension": "uV",
+                "sample_frequency": EDF_SRATE,
+                "physical_min": -100,
+                "physical_max": 100,
+                "digital_min": -32768,
+                "digital_max": 32767,
+                "transducer": "",
+                "prefilter": "",
+            }
+            for index in range(len(signals))
+        ]
+    )
+    writer.writeSamples(signals)
+    for onset, text in EDF_ANNOTATIONS:
+        writer.writeAnnotation(onset, 0.5, text)
+    writer.close()
+    (eeg_dir / "sub-01_task-x_eeg.json").write_text(
+        json.dumps({"TaskName": "x", "SamplingFrequency": EDF_SRATE, "EEGReference": "Cz", "PowerLineFrequency": 50})
+    )
+    (eeg_dir / "sub-01_task-x_channels.tsv").write_text("name\ttype\tunits\nC0\tEEG\tuV\nC1\tEEG\tuV\n")
+    # A and B duplicate EDF annotations; D exists only in events.tsv
+    (eeg_dir / "sub-01_task-x_events.tsv").write_text(
+        "onset\tduration\ttrial_type\n0.0\t0.5\tA\n1.0\t0.5\tB\n5.0\t0.5\tD\n"
+    )
+    return edf_path
+
+
+def test_raw_edf_loader_returns_one_based_event_latencies(tmp_path: Path) -> None:
+    from eegprep.plugins.EEG_BIDS.raw import load_raw_eeg_file
+
+    edf_path = _write_edf_bids_dataset(tmp_path)
+    eeg, srate, times_sec, _report = load_raw_eeg_file(
+        str(edf_path),
+        dtype=np.float64,
+        numeric_null=np.array([]),
+        warning=lambda msg: None,
+        verbose=False,
+    )
+
+    assert srate == EDF_SRATE
+    assert len(times_sec) == EDF_SRATE * EDF_SECONDS
+    assert [event["type"] for event in eeg["event"]] == ["A", "B", "C"]
+    assert [int(event["latency"]) for event in eeg["event"]] == [1, 101, 1000]
+
+
+def test_pop_load_frombids_merge_deduplicates_raw_and_tsv_events(tmp_path: Path) -> None:
+    from eegprep.functions.popfunc.pop_load_frombids import pop_load_frombids
+
+    edf_path = _write_edf_bids_dataset(tmp_path)
+
+    merged = pop_load_frombids(str(edf_path), bidsevent="merge", verbose=False)
+    assert [(event["type"], int(event["latency"])) for event in merged["event"]] == [
+        ("A", 1),
+        ("B", 101),
+        ("D", 501),
+        ("C", 1000),
+    ]
+
+    appended = pop_load_frombids(str(edf_path), bidsevent="append", verbose=False)
+    assert [(event["type"], int(event["latency"])) for event in appended["event"]] == [
+        ("A", 1),
+        ("A", 1),
+        ("B", 101),
+        ("B", 101),
+        ("D", 501),
+        ("C", 1000),
+    ]
 
 
 def test_raw_set_loader_returns_eeg_and_timing_metadata() -> None:


### PR DESCRIPTION
🤖 

## Problem

EEG event latencies are 1-based (latency 1.0 = first sample, EEGLAB convention). The neo-based event reader in `src/eegprep/plugins/EEG_BIDS/raw.py` (`_read_neo_events`, used for `.edf`/`.bdf`/`.vhdr`) computed `np.searchsorted(times_sec, all_times)` without the `+1`, so annotations stored in the raw file came out 0-based: an event on the first sample had latency 0.

The `events.tsv` path in `pop_load_frombids` already adds 1 (`ev_lats = ev_lats + 1`). Consequences:

- Raw-file events were one sample early relative to `events.tsv` events (and relative to `.set` files and `mne_raw_to_eeg`, which are 1-based).
- `bidsevent='merge'` compared 0-based raw latencies against 1-based tsv latencies, so its de-duplication missed every match: an event present in both sources was kept twice.
- `bidsevent=False`/`'append'` returned off-by-one raw latencies.

## Fix

`raw.py`: `event_latencies = np.searchsorted(times_sec, all_times) + 1` — same rounding policy as the tsv path, now 1-based. One-line change; all consumers in `pop_load_frombids` (`replace`, `merge`, `append`, `False`) are unchanged.

## Verification

New tests in `tests/test_bids_load_frombids_helpers.py` write a real EDF+ file with `pyedflib` (100 Hz, 10 s, 2 channels) into a minimal BIDS tree (`dataset_description.json`, `*_eeg.json`, `*_channels.tsv`, `*_events.tsv`) with annotations at 0.0 s, 1.0 s, 9.99 s, and an `events.tsv` containing two of those plus one extra event at 5.0 s.

Latencies from `load_raw_eeg_file` on that EDF:

| | before | after |
|---|---|---|
| raw-file annotations | `[0, 100, 999]` | `[1, 101, 1000]` |
| `bidsevent='merge'` event count | 6 (A and B duplicated at 0 vs 1) | 4 (union: A@1, B@101, D@501, C@1000) |
| `bidsevent='append'` | 6, raw copies off by one | 6, duplicates at identical latencies |
| `bidsevent='replace'` | 3 (tsv only) | 3 (unchanged) |
| `bidsevent=False` | `[0, 100, 999]` | `[1, 101, 1000]` |

Both new tests fail on `origin/develop` and pass with the fix.

```
EEGPREP_SKIP_MATLAB=1 pytest tests/test_import_edf.py tests/test_bids_load_frombids_helpers.py \
  tests/test_bids_gen_derived_fpath.py tests/test_bids_preproc.py tests/test_bids_preproc_old.py \
  tests/test_cli_bids_migrate_commands.py -q
# 18 passed, 2 skipped (MATLAB not available)

EEGPREP_SKIP_MATLAB=1 pytest tests/test_file_menu_pop_functions.py tests/test_sample_data_pop_functions.py \
  tests/test_bids_load_frombids_helpers.py -q
# 78 passed

ruff check / ruff format --check on the two changed files: clean
```

No docs change: `docs/source/user_guide/` does not describe raw-file BIDS event latency behaviour.

## Related, not changed here

- `raw.py` leaves neo annotation durations as returned by neo (seconds for EDF/BDF; `0.5` in the test), whereas the `events.tsv` path converts to samples (`round(max(1, Fs*duration))`). Separate inconsistency, left out of this PR.
- `bids_preproc.py` (events.tsv export) indexes `times[e['latency']]` with a 1-based latency, i.e. one sample late; pre-existing for tsv-derived events and unrelated to this change.
