### PR TITLE
Fix docs example lint and gallery path resolution

### DIFF
--- a/docs/source/examples/plot_data_plotting.py
+++ b/docs/source/examples/plot_data_plotting.py
@@ -12,6 +12,7 @@ figure is built and returned instead of opening a window.
 # Load the epoched dataset with an ICA decomposition
 # --------------------------------------------------
 
+import tempfile
 from pathlib import Path
 
 import matplotlib
@@ -20,6 +21,7 @@ import numpy as np
 matplotlib.use("Agg")
 
 import eegprep
+from eegprep.functions.sigprocfunc.headplot import default_headplot_mesh_transform
 from eegprep import (
     eeg_pvaf,
     pop_envtopo,
@@ -40,6 +42,13 @@ SAMPLE_DATA = REPO_ROOT / "sample_data"
 
 EEG = pop_loadset(SAMPLE_DATA / "eeglab_data_epochs_ica.set")
 EPOCH_MS = [EEG["xmin"] * 1000.0, EEG["xmax"] * 1000.0]
+# 3-D head plots need a spline setup file; the first pop_headplot call builds it
+# (Plot > ERP map series > 3-D "setup"), later calls reuse it with ``load``.
+SPLINE_FILE = Path(tempfile.mkdtemp()) / "eeglab_data_epochs_ica.spl"
+HEADPLOT_SETUP = {
+    "splinefile": str(SPLINE_FILE),
+    "transform": default_headplot_mesh_transform(chaninfo=EEG["chaninfo"]),
+}
 print(f"data {EEG['data'].shape} srate {EEG['srate']:g} trials {EEG['trials']}")
 print(f"components {np.asarray(EEG['icaweights']).shape[0]} epoch {EPOCH_MS[0]:g}..{EPOCH_MS[1]:g} ms")
 
@@ -50,7 +59,7 @@ print(f"components {np.asarray(EEG['icaweights']).shape[0]} epoch {EPOCH_MS[0]:g
 fig_timtopo, com_timtopo = pop_timtopo(EEG, [100, 300], timerange=[-100, 600], plot="off", return_com=True)
 fig_plottopo = pop_plottopo(EEG, chans=list(range(1, 33)), plot="off")
 figs_erp2d = pop_topoplot(EEG, 1, [0, 100, 200, 300], plot="off")
-figs_erp3d = pop_headplot(EEG, 1, [100, 300], load=SAMPLE_DATA / "eeglab_data_epochs_ica.spl", plot="off")
+figs_erp3d = pop_headplot(EEG, 1, [100, 300], setup=HEADPLOT_SETUP, plot="off")
 print("timtopo history:", com_timtopo)
 print(f"ERP map series: {len(figs_erp2d)} 2-D figure(s), {len(figs_erp3d)} 3-D figure(s)")
 
@@ -100,7 +109,7 @@ fig_envtopo, com_envtopo = pop_envtopo(EEG, [-100, 600], compnums=list(range(1, 
 comp_image = pop_erpimage(EEG, 0, 1, smooth=10, decimate=2, plot="off")
 comp_tf = pop_newtimef(EEG, 0, 1, EPOCH_MS, [3, 0.8], plot="off")
 figs_comp2d = pop_topoplot(EEG, 0, [1, 2, 3, 4, 5], plot="off")
-figs_comp3d = pop_headplot(EEG, 0, [1, 2], load=SAMPLE_DATA / "eeglab_data_epochs_ica.spl", plot="off")
+figs_comp3d = pop_headplot(EEG, 0, [1, 2], load=SPLINE_FILE, plot="off")
 pvaf, _, _ = eeg_pvaf(EEG, [1, 2, 3, 4, 5])
 print(f"component spectra {comp_spectra['spectra'].shape}")
 print(f"pvaf of components 1-5: {float(np.atleast_1d(pvaf)[0]):.2f}%")

--- a/docs/source/examples/plot_data_plotting.py
+++ b/docs/source/examples/plot_data_plotting.py
@@ -19,6 +19,7 @@ import numpy as np
 
 matplotlib.use("Agg")
 
+import eegprep
 from eegprep import (
     eeg_pvaf,
     pop_envtopo,
@@ -34,7 +35,7 @@ from eegprep import (
     pop_topoplot,
 )
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(eegprep.__file__).resolve().parents[2]  # sphinx-gallery defines no __file__
 SAMPLE_DATA = REPO_ROOT / "sample_data"
 
 EEG = pop_loadset(SAMPLE_DATA / "eeglab_data_epochs_ica.set")

--- a/docs/source/examples/plot_data_structures.py
+++ b/docs/source/examples/plot_data_structures.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import numpy as np
 
+import eegprep
 from eegprep import (
     eeg_emptyset,
     eeg_findboundaries,
@@ -42,7 +43,7 @@ print("fields:", ", ".join(sorted(EEG_EMPTY)))
 # Continuous data is channel-major ``(nbchan, pnts)``. ``trials`` is 1.
 # ``xmin`` / ``xmax`` are seconds; ``times`` is milliseconds.
 
-SAMPLE_DIR = Path(__file__).resolve().parents[3] / "sample_data"
+SAMPLE_DIR = Path(eegprep.__file__).resolve().parents[2] / "sample_data"  # sphinx-gallery defines no __file__
 
 EEG = pop_loadset(str(SAMPLE_DIR / "eeglab_data.set"))
 print("setname:", EEG["setname"])

--- a/docs/source/examples/plot_dataset_management.py
+++ b/docs/source/examples/plot_dataset_management.py
@@ -18,6 +18,7 @@ import matplotlib
 
 matplotlib.use("Agg")
 
+import eegprep
 from eegprep import (  # noqa: E402
     EEGPrepSession,
     eeg_retrieve,
@@ -30,7 +31,7 @@ from eegprep import (  # noqa: E402
     pop_saveset,
 )
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(eegprep.__file__).resolve().parents[2]  # sphinx-gallery defines no __file__
 TUTORIAL_SET = REPO_ROOT / "sample_data" / "eeglab_data.set"
 
 EEG = pop_loadset(str(TUTORIAL_SET))

--- a/docs/source/examples/plot_extract_epochs.py
+++ b/docs/source/examples/plot_extract_epochs.py
@@ -19,6 +19,7 @@ import matplotlib
 
 matplotlib.use("Agg")
 
+import eegprep
 from eegprep import (
     eeg_checkset,
     pop_epoch,
@@ -28,7 +29,7 @@ from eegprep import (
     pop_selectevent,
 )
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(eegprep.__file__).resolve().parents[2]  # sphinx-gallery defines no __file__
 input_file = REPO_ROOT / "sample_data" / "eeglab_data.set"
 
 EEG = pop_loadset(input_file)
@@ -40,9 +41,7 @@ print("event types:", sorted({str(event["type"]) for event in EEG["event"]}))
 # (``Tools > Extract epochs``). ``pop_epoch`` returns the epoched dataset plus
 # the history command the GUI and console record.
 
-EEG, epoch_com = pop_epoch(
-    EEG, ["square"], [-1, 2], newname="Square epochs", return_com=True
-)
+EEG, epoch_com = pop_epoch(EEG, ["square"], [-1, 2], newname="Square epochs", return_com=True)
 print("epoched:", EEG["data"].shape, "trials:", EEG["trials"])
 print("epoch range (s):", EEG["xmin"], EEG["xmax"])
 print(epoch_com)
@@ -66,9 +65,7 @@ print(select_time_com)
 # Select epochs by index. Epoch selectors are EEGLAB-facing 1-based indices, so
 # ``trial=[1, ..., 10]`` keeps the first ten epochs.
 
-EEG_first10, select_trial_com = pop_select(
-    EEG, trial=list(range(1, 11)), return_com=True
-)
+EEG_first10, select_trial_com = pop_select(EEG, trial=list(range(1, 11)), return_com=True)
 print("first 10 epochs:", EEG_first10["data"].shape)
 print(select_trial_com)
 

--- a/docs/source/examples/plot_group_analysis_study.py
+++ b/docs/source/examples/plot_group_analysis_study.py
@@ -18,6 +18,7 @@ import matplotlib
 
 matplotlib.use("Agg")
 
+import eegprep
 from eegprep import (  # noqa: E402
     pop_clust,
     pop_listfactors,
@@ -33,7 +34,7 @@ from eegprep import (  # noqa: E402
     std_maketrialinfo,
 )
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(eegprep.__file__).resolve().parents[2]  # sphinx-gallery defines no __file__
 SAMPLE = REPO_ROOT / "sample_data" / "eeglab_data_epochs_ica.set"
 
 # %%
@@ -71,9 +72,7 @@ print("factors:", [f"{f['label']}={f['value']}" for f in factors])
 # Add a second design contrasting the two groups and select it
 # (``Study > Select/Edit study design(s)``).
 
-STUDY, com = std_makedesign(
-    STUDY, ALLEEG, 2, name="group contrast", variable1="group", return_com=True
-)
+STUDY, com = std_makedesign(STUDY, ALLEEG, 2, name="group contrast", variable1="group", return_com=True)
 STUDY, ALLEEG, com = pop_studydesign(STUDY, ALLEEG, 2, return_com=True)
 print("designs:", [d.get("name") for d in STUDY["design"]])
 print("current design:", STUDY["currentdesign"])
@@ -82,9 +81,7 @@ print("current design:", STUDY["currentdesign"])
 # Precompute channel ERP and spectrum measures
 # (``Study > Precompute channel measures``).
 
-STUDY, ALLEEG, com = pop_precomp(
-    STUDY, ALLEEG, "channels", erp="on", spec="on", return_com=True
-)
+STUDY, ALLEEG, com = pop_precomp(STUDY, ALLEEG, "channels", erp="on", spec="on", return_com=True)
 print("cached channel groups:", len(STUDY["changrp"]))
 print("cached fields:", sorted(k for k in STUDY["changrp"][0] if k.endswith("data")))
 
@@ -100,9 +97,7 @@ print("times:", f"{erptimes[0]:.1f} .. {erptimes[-1]:.1f} ms")
 # Component measures, preclustering array, and k-means clustering
 # (``Study > Precompute component measures``, ``Study > PCA clustering``).
 
-STUDY, ALLEEG, com = pop_precomp(
-    STUDY, ALLEEG, "components", scalp="on", erp="on", return_com=True
-)
+STUDY, ALLEEG, com = pop_precomp(STUDY, ALLEEG, "components", scalp="on", erp="on", return_com=True)
 STUDY, ALLEEG, com = pop_preclust(
     STUDY,
     ALLEEG,

--- a/docs/source/examples/plot_history_to_script.py
+++ b/docs/source/examples/plot_history_to_script.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 import numpy as np
 
+import eegprep
 from eegprep import (
     EEGPrepSession,
     eegh,
@@ -41,7 +42,7 @@ from eegprep import (
     pop_saveh,
 )
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(eegprep.__file__).resolve().parents[2]  # sphinx-gallery defines no __file__
 SAMPLE = REPO_ROOT / "sample_data" / "eeglab_data.set"
 
 _MASKS: list[tuple[str, str]] = [(str(REPO_ROOT), "<repo>")]
@@ -52,6 +53,7 @@ def mask(text: str) -> str:
     for actual, label in _MASKS:
         text = text.replace(actual, label)
     return text
+
 
 # %%
 # Interactive-style pass, recording history

--- a/docs/source/examples/plot_import_data.py
+++ b/docs/source/examples/plot_import_data.py
@@ -22,7 +22,7 @@ import eegprep
 
 def find_sample_data() -> Path:
     """Return the repository ``sample_data`` directory."""
-    for parent in Path(__file__).resolve().parents:
+    for parent in Path(eegprep.__file__).resolve().parents:  # sphinx-gallery defines no __file__
         candidate = parent / "sample_data"
         if candidate.is_dir():
             return candidate

--- a/docs/source/examples/plot_preprocess_data.py
+++ b/docs/source/examples/plot_preprocess_data.py
@@ -16,9 +16,10 @@ import matplotlib
 
 matplotlib.use("Agg")
 
+import eegprep
 from eegprep import pop_eegfiltnew, pop_loadset, pop_reref, pop_resample, pop_spectopo
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(eegprep.__file__).resolve().parents[2]  # sphinx-gallery defines no __file__
 EEG = pop_loadset(REPO_ROOT / "sample_data" / "eeglab_data.set")
 
 print(f"loaded    : {EEG['nbchan']} chan, {EEG['pnts']} pnts, {EEG['srate']:g} Hz")

--- a/docs/source/examples/plot_quickstart_tour.py
+++ b/docs/source/examples/plot_quickstart_tour.py
@@ -13,9 +13,10 @@ scrolling channel browser. Everything runs headless.
 
 from pathlib import Path
 
+import eegprep
 from eegprep import eeg_checkset, eegplot, pop_comments, pop_editeventvals, pop_loadset
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(eegprep.__file__).resolve().parents[2]  # sphinx-gallery defines no __file__
 dataset = REPO_ROOT / "sample_data" / "eeglab_data.set"
 
 EEG = pop_loadset(dataset)

--- a/docs/source/examples/plot_reject_artifacts.py
+++ b/docs/source/examples/plot_reject_artifacts.py
@@ -22,6 +22,7 @@ matplotlib.use("Agg")
 
 import numpy as np
 
+import eegprep
 from eegprep import (
     eeg_eegrej,
     eegplot,
@@ -40,7 +41,7 @@ from eegprep import (
 
 def _sample_data_dir() -> Path:
     """Locate the repository ``sample_data`` directory from this file."""
-    for parent in Path(__file__).resolve().parents:
+    for parent in Path(eegprep.__file__).resolve().parents:  # sphinx-gallery defines no __file__
         candidate = parent / "sample_data"
         if candidate.is_dir():
             return candidate

--- a/docs/source/examples/plot_source_analysis_dipfit.py
+++ b/docs/source/examples/plot_source_analysis_dipfit.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import numpy as np
 
+import eegprep
 from eegprep import (
     pop_dipfit_gridsearch,
     pop_dipfit_nonlinear,
@@ -25,7 +26,9 @@ from eegprep import (
     pop_multifit,
 )
 
-SAMPLE = Path(__file__).resolve().parents[3] / "sample_data" / "eeglab_data_epochs_ica.set"
+SAMPLE = (
+    Path(eegprep.__file__).resolve().parents[2] / "sample_data" / "eeglab_data_epochs_ica.set"
+)  # sphinx-gallery defines no __file__
 
 # 1. Load a dataset that already carries channel locations and an ICA decomposition.
 EEG = pop_loadset(str(SAMPLE))

--- a/docs/source/examples/plot_source_analysis_dipfit.py
+++ b/docs/source/examples/plot_source_analysis_dipfit.py
@@ -1,5 +1,8 @@
-"""Equivalent-dipole source localization of ICA components with EEGPrep DIPFIT.
+"""
+Source Analysis with DIPFIT
+===========================
 
+Equivalent-dipole source localization of ICA components with EEGPrep DIPFIT.
 Mirrors EEGLAB's "Source analysis" tutorial workflow: choose a head model,
 coarse-fit component dipoles on a grid, refine them, then read the resulting
 ``EEG.dipfit.model`` entries.
@@ -26,9 +29,9 @@ from eegprep import (
     pop_multifit,
 )
 
-SAMPLE = (
-    Path(eegprep.__file__).resolve().parents[2] / "sample_data" / "eeglab_data_epochs_ica.set"
-)  # sphinx-gallery defines no __file__
+# sphinx-gallery defines no __file__, so anchor on the installed package.
+REPO_ROOT = Path(eegprep.__file__).resolve().parents[2]
+SAMPLE = REPO_ROOT / "sample_data" / "eeglab_data_epochs_ica.set"
 
 # 1. Load a dataset that already carries channel locations and an ICA decomposition.
 EEG = pop_loadset(str(SAMPLE))

--- a/tests/test_math_backend.py
+++ b/tests/test_math_backend.py
@@ -6,8 +6,10 @@ from eegprep.utils import math_backend
 
 
 def test_math_backend_info_reports_real_build_and_runtime_state(monkeypatch):
+    # Isolate from the runner's own thread settings so only the value set here is reported.
+    for name in math_backend._THREAD_ENVIRONMENT_VARIABLES:
+        monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("OMP_NUM_THREADS", "3")
-    monkeypatch.delenv("MKL_NUM_THREADS", raising=False)
 
     info = math_backend.get_math_backend_info()
 


### PR DESCRIPTION
🤖 Restore a green CI baseline. Every develop push and PR since the September 6 merge (`2e8cbb28`, which brought the August docs commits onto develop) fails the "Ruff and ty" and "Build Documentation" jobs, and because the test matrix depends on the lint job, no CI tests have run since then.

## Failure 1: Ruff format

`plot_extract_epochs.py`, `plot_group_analysis_study.py`, and `plot_history_to_script.py` were not formatted with `ruff format`. Fixed by running the formatter; no semantic change.

## Failure 2: Documentation build

All 11 user-guide examples located `sample_data` with `Path(__file__).resolve().parents[3]`. sphinx-gallery deliberately never defines `__file__` in the execution namespace ("Don't ever support `__file__`: Issues #166 #212" in `gen_rst.py`), so every example raised `NameError` during the gallery build. The examples still passed `tests/test_public_api_examples.py` because `runpy` does define `__file__`.

Fixed by anchoring on the installed package instead: `Path(eegprep.__file__).resolve().parents[2]` is the repository root for the editable install used by CI, tests, and development, and it is defined under both `runpy` and sphinx-gallery. The two examples that walked up `Path(__file__).parents` looking for `sample_data` now walk up from the package path. One short comment per file records why.

## Failure 3: Headplot spline file absent in CI

`plot_data_plotting.py` loaded `sample_data/eeglab_data_epochs_ica.spl`. `.gitignore` ignores `sample_data/*`, so the `.spl` file exists only on developer machines and the gallery build failed on the first `pop_headplot` call. The example now builds the spline once with `pop_headplot(..., setup={...})` into a temporary directory (the "setup" path of Plot > ERP map series > 3-D) and reuses it with `load=` for the component maps. Building the spline requires an explicit `transform`; the example uses `default_headplot_mesh_transform` for the dataset's template, which is what EEGLAB's dialog prefills.

## DIPFIT example gallery title

`plot_source_analysis_dipfit.py` had no RST title in its module docstring, so sphinx-gallery emitted "toctree contains reference to document that doesn't have a title" warnings and a broken cross-reference in the execution-times table. Added the title header.

## Test isolation

`tests/test_math_backend.py` asserted that `thread_environment` contains exactly `OMP_NUM_THREADS` but only cleared `MKL_NUM_THREADS`. Any runner exporting another recognised thread variable made the test fail. The test now clears every variable in `_THREAD_ENVIRONMENT_VARIABLES` before setting the one it checks.

## Verification

- Each example executed with `exec(compile(src, ...), {"__name__": "__main__", "__doc__": ""})` from the examples directory, mirroring sphinx-gallery's namespace: 16 of 16 runnable examples pass (`plot_reject_artifacts.py` skipped locally, torch not installed here; CI installs the torch extra).
- `tests/test_public_api_examples.py`: 16 passed (same torch-dependent case deselected locally).
- `ruff check` and `ruff format --check` clean on all tracked files; `./pre-commit.py --changed-from origin/develop` clean.
- CI on this PR: Build Documentation, Pre-commit, Ruff and ty, and the five test-matrix jobs all pass; this is the first run since September 6 where the test matrix executed.
