### PR TITLE
Keep dataset numbers stable when deleting datasets

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,9 +13,13 @@ Unreleased
 - Deleting datasets (``pop_delset``, Edit > Delete dataset(s) from memory) now empties
   the slot in place like EEGLAB instead of shifting later datasets down, so dataset
   numbers in the Datasets menu, ``CURRENTSET``, and the history stay valid. ``eeg_store``
-  stores new datasets in the lowest empty slot, trailing empty slots are dropped, STUDY
-  functions ignore empty slots, and ``pop_delset`` raises for a dataset number that does
-  not exist.
+  stores new datasets in the lowest empty slot, trailing empty slots are dropped, and
+  ``pop_delset`` raises for a dataset number that does not exist. A dataset selection can
+  no longer land on an emptied slot; it falls back to a remaining dataset the way EEGLAB's
+  redraw does. Creating or editing a STUDY still compacts the empty slots away, because a
+  STUDY needs contiguous dataset numbers, but the selection now follows the dataset it was
+  on instead of its old number. Editing a STUDY design, precomputing measures, and
+  preclustering no longer modify ``ALLEEG``, matching EEGLAB's ``e_plot_study``.
 - ``pop_prop`` (Plot > Channel/Component properties) now matches EEGLAB's three-panel
   layout: a scalp map, an ERP image, and the activity power spectrum. The ERP panel is a
   full ERP image (reusing ``erpimage``) instead of a single averaged trace, the spectrum is

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,12 @@ the `GitHub Releases <https://github.com/sccn/eegprep/releases>`_ page.
 Unreleased
 ==========
 
+- Deleting datasets (``pop_delset``, Edit > Delete dataset(s) from memory) now empties
+  the slot in place like EEGLAB instead of shifting later datasets down, so dataset
+  numbers in the Datasets menu, ``CURRENTSET``, and the history stay valid. ``eeg_store``
+  stores new datasets in the lowest empty slot, trailing empty slots are dropped, STUDY
+  functions ignore empty slots, and ``pop_delset`` raises for a dataset number that does
+  not exist.
 - ``pop_prop`` (Plot > Channel/Component properties) now matches EEGLAB's three-panel
   layout: a scalp map, an ERP image, and the activity power spectrum. The ERP panel is a
   full ERP image (reusing ``erpimage``) instead of a single averaged trace, the spectrum is

--- a/docs/source/examples/plot_data_structures.py
+++ b/docs/source/examples/plot_data_structures.py
@@ -152,7 +152,8 @@ print("eeg_getica(EEG, 1):", eeg_getica(EPOCHED, 1).shape)
 # -----------------------------
 # Loaded datasets live in ``ALLEEG``, a plain Python list. ``CURRENTSET``
 # holds 1-based dataset numbers, matching what the GUI Datasets menu and the
-# console show. ``eeg_store`` appends or overwrites; ``eeg_retrieve`` selects.
+# console show. ``eeg_store`` fills the lowest empty slot or overwrites;
+# ``eeg_retrieve`` selects.
 
 ALLEEG, _EEG, CURRENTSET = eeg_store([], EEG, 0)
 ALLEEG, _EEG, CURRENTSET = eeg_store(ALLEEG, EPOCHED, 0)

--- a/docs/source/examples/plot_dataset_management.py
+++ b/docs/source/examples/plot_dataset_management.py
@@ -105,8 +105,9 @@ with tempfile.TemporaryDirectory() as tmpdir:
 
 # %%
 # Delete datasets from memory (``Edit > Delete dataset(s) from memory`` or
-# ``File > Clear dataset(s)``).
+# ``File > Clear dataset(s)``). As in EEGLAB, the slot is emptied in place, so the
+# remaining datasets keep their numbers; trailing empty slots are dropped.
 
-ALLEEG, delete_com = pop_delset(ALLEEG, [3])
-print("datasets in memory:", len(ALLEEG))
+ALLEEG, delete_com = pop_delset(ALLEEG, [2])
+print("dataset numbers still in memory:", [index for index, eeg in enumerate(ALLEEG, start=1) if eeg])
 print(delete_com)

--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -98,6 +98,11 @@ Practical rules:
   one-based on disk.
 * Single-trial datasets have no ``epoch`` structure: ``eeg_checkset`` empties
   it and removes ``event[i]["epoch"]``, as EEGLAB does.
+* Deleting a dataset empties its ``ALLEEG`` slot (an empty ``{}`` entry) instead
+  of shifting later datasets down, so the numbers in the Datasets menu,
+  ``CURRENTSET``, and the history stay valid, as in EEGLAB. New datasets fill the
+  lowest empty slot, trailing empty slots are dropped, and STUDY functions skip
+  empty slots.
 
 For epoched data, ``EEG["data"][:, :, trial_index]`` is zero-based Python
 indexing. User-facing epoch and component selectors in GUI dialogs use

--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -101,8 +101,22 @@ Practical rules:
 * Deleting a dataset empties its ``ALLEEG`` slot (an empty ``{}`` entry) instead
   of shifting later datasets down, so the numbers in the Datasets menu,
   ``CURRENTSET``, and the history stay valid, as in EEGLAB. New datasets fill the
-  lowest empty slot, trailing empty slots are dropped, and STUDY functions skip
-  empty slots.
+  lowest empty slot and trailing empty slots are dropped. Selecting an empty slot
+  is not possible: the selection falls back to a remaining dataset, as EEGLAB's
+  redraw does.
+* Building a STUDY needs contiguous dataset numbers, so creating or editing one
+  compacts the empty slots away and renumbers the remaining datasets. EEGLAB's
+  ``std_editset`` does the same. Your selection follows the dataset it was on
+  rather than the number. Editing a STUDY design, precomputing measures, and
+  preclustering leave ``ALLEEG`` untouched, as in EEGLAB.
+
+Two deliberate differences from EEGLAB:
+
+* After a delete, EEGPrep selects the nearest remaining dataset at or above the
+  deleted number, while EEGLAB always falls back to the lowest-numbered dataset.
+  Staying near the deleted dataset is friendlier when you delete from a long list.
+* EEGLAB refuses to delete when only one dataset is loaded and tells you to clear
+  all datasets instead. EEGPrep deletes it and leaves an empty ``ALLEEG``.
 
 For epoched data, ``EEG["data"][:, :, trial_index]`` is zero-based Python
 indexing. User-facing epoch and component selectors in GUI dialogs use

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -21,7 +21,7 @@ import eegprep
 from eegprep.functions.adminfunc.eegh import eegh, eegh_find
 from eegprep.extension_runtime import ExtensionRuntime
 from eegprep.functions.adminfunc.eeglab import gui
-from eegprep.functions.guifunc.session import EEGPrepSession, normalize_dataset_indices
+from eegprep.functions.guifunc.session import EEGPrepSession, nearest_dataset_index, normalize_dataset_indices
 from eegprep.functions.popfunc.pop_eegplot import eegplot_accept_creates_dataset
 from eegprep.functions.popfunc.pop_newset import pop_newset
 
@@ -1429,16 +1429,17 @@ def _normalize_currentset(value: Any) -> list[int]:
 
 def _currentset_after_alleeg_change(currentset: list[int], previous_eeg: Any, alleeg: list[Any]) -> list[int]:
     """Follow the selected datasets to their new positions, else select the nearest remaining one."""
-    if not alleeg:
-        return []
     previous = previous_eeg if isinstance(previous_eeg, list) else [previous_eeg]
     followed = [index + 1 for index, dataset in enumerate(alleeg) if any(dataset is item for item in previous)]
     if followed:
         return followed
-    valid = [index for index in currentset if index <= len(alleeg)]
+    valid = [index for index in currentset if index <= len(alleeg) and alleeg[index - 1]]
     if valid:
         return valid
-    return [len(alleeg)] if currentset else []
+    if not currentset:
+        return []
+    target = nearest_dataset_index(alleeg, min(currentset))
+    return [] if target is None else [target]
 
 
 _IN_PLACE_MUTATION_METHODS = frozenset(

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -21,7 +21,7 @@ import eegprep
 from eegprep.functions.adminfunc.eegh import eegh, eegh_find
 from eegprep.extension_runtime import ExtensionRuntime
 from eegprep.functions.adminfunc.eeglab import gui
-from eegprep.functions.guifunc.session import EEGPrepSession, nearest_dataset_index, normalize_dataset_indices
+from eegprep.functions.guifunc.session import EEGPrepSession, follow_dataset_selection, normalize_dataset_indices
 from eegprep.functions.popfunc.pop_eegplot import eegplot_accept_creates_dataset
 from eegprep.functions.popfunc.pop_newset import pop_newset
 
@@ -36,6 +36,7 @@ _TUPLE_ASSIGNMENT_TARGET_PATTERN = re.compile(
     r"(^|;\s*)\(([A-Za-z_][A-Za-z0-9_]*(?:,\s*[A-Za-z_][A-Za-z0-9_]*)+)\)\s*="
 )
 _POP_INTERP_CHANNELS_PATTERN = re.compile(r"(pop_interp\s*\(\s*EEG\s*,\s*)\[([0-9,\s]+)\]")
+_ALLEEG_ASSIGNMENT_PATTERN = re.compile(r"^\s*ALLEEG\s*=")
 _PYTHON_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _CONSOLE_COMMAND_EXPORTS = {"pop_newset": pop_newset}
 _BROWSER_ACCEPT_POP_FUNCTIONS = {
@@ -101,6 +102,32 @@ class ConsoleDatasetResult:
         if len(command) > POP_RESULT_PREVIEW_LIMIT:
             command = command[: POP_RESULT_PREVIEW_LIMIT - 3] + "..."
         return f"<EEGPrep dataset result: CURRENTSET={self.currentset!r}, LASTCOM={command!r}>"
+
+
+class ConsoleAllEegResult:
+    """Compact, unpackable result for ``pop_*`` calls returning ``(ALLEEG, command)``."""
+
+    def __init__(self, alleeg: list[Any], currentset: Any, command: str) -> None:
+        self.alleeg = alleeg
+        self.currentset = currentset
+        self.command = command
+
+    def __iter__(self) -> Iterator[Any]:
+        yield self.alleeg
+        yield self.command
+
+    def __getitem__(self, index: int) -> Any:
+        return (self.alleeg, self.command)[index]
+
+    def __len__(self) -> int:
+        return 2
+
+    def __repr__(self) -> str:
+        command = self.command or "(no history command)"
+        if len(command) > POP_RESULT_PREVIEW_LIMIT:
+            command = command[: POP_RESULT_PREVIEW_LIMIT - 3] + "..."
+        datasets = sum(1 for dataset in self.alleeg if dataset)
+        return f"<EEGPrep dataset list: {datasets} dataset(s), CURRENTSET={self.currentset!r}, LASTCOM={command!r}>"
 
 
 class ConsoleStudyResult:
@@ -383,7 +410,7 @@ class EEGPrepConsoleWorkspace:
             if "CURRENTSET" in targets:
                 current = _normalize_currentset(self.namespace.get("CURRENTSET"))
             else:
-                current = _currentset_after_alleeg_change(self.session.CURRENTSET, self.session.EEG, alleeg)
+                current = follow_dataset_selection(alleeg, self.session.EEG, self.session.CURRENTSET)
             command = "" if eeg_changed else pending_history
             self.session.apply_workspace_state(
                 alleeg=alleeg,
@@ -450,6 +477,20 @@ class EEGPrepConsoleWorkspace:
             return ConsoleDatasetResult(
                 self.session.ALLEEG, self.session.EEG, self.session.current_set_value(), command
             )
+
+        alleeg_state = _extract_pop_alleeg_state(result)
+        if alleeg_state is not None:
+            alleeg, command = alleeg_state
+            self.session.apply_workspace_state(
+                alleeg=alleeg,
+                currentset=follow_dataset_selection(alleeg, self.session.EEG, self.session.CURRENTSET),
+                command=command,
+                append_dataset_history=False,
+            )
+            self._pop_updated_session = True
+            self.pull_from_session()
+            self._refresh()
+            return ConsoleAllEegResult(self.session.ALLEEG, self.session.current_set_value(), command)
 
         study_state = _extract_pop_study_state(result)
         if study_state is not None:
@@ -1367,6 +1408,26 @@ def _extract_pop_eeg_and_command(result: Any) -> tuple[Any | None, str]:
     return None, ""
 
 
+def _extract_pop_alleeg_state(result: Any) -> tuple[list[Any], str] | None:
+    """Recognize an ``(ALLEEG, command)`` result such as ``pop_delset``'s.
+
+    The command names its assignment target, so ``ALLEEG = pop_delset( ALLEEG, [2] );``
+    is distinguishable from a ``pop_*`` that returns a list of selected datasets. Without
+    this the returned list is either discarded (a deleted slot fails ``_is_eeg_selection``)
+    or mistaken for new datasets and appended.
+    """
+    if not isinstance(result, tuple) or len(result) != 2:
+        return None
+    alleeg, command = result
+    if not isinstance(alleeg, list) or not isinstance(command, str):
+        return None
+    if not _ALLEEG_ASSIGNMENT_PATTERN.match(command):
+        return None
+    if not all(isinstance(item, dict) and (not item or _is_eeg_selection(item)) for item in alleeg):
+        return None
+    return alleeg, command.strip()
+
+
 def _extract_pop_dataset_state(result: Any) -> tuple[list[dict[str, Any]], Any, Any, str] | None:
     if not isinstance(result, tuple) or len(result) < 4:
         return None
@@ -1425,21 +1486,6 @@ def _normalize_currentset(value: Any) -> list[int]:
         return normalize_dataset_indices(value)
     except ValueError as exc:
         raise ValueError("CURRENTSET must be a 1-based integer or list of integers") from exc
-
-
-def _currentset_after_alleeg_change(currentset: list[int], previous_eeg: Any, alleeg: list[Any]) -> list[int]:
-    """Follow the selected datasets to their new positions, else select the nearest remaining one."""
-    previous = previous_eeg if isinstance(previous_eeg, list) else [previous_eeg]
-    followed = [index + 1 for index, dataset in enumerate(alleeg) if any(dataset is item for item in previous)]
-    if followed:
-        return followed
-    valid = [index for index in currentset if index <= len(alleeg) and alleeg[index - 1]]
-    if valid:
-        return valid
-    if not currentset:
-        return []
-    target = nearest_dataset_index(alleeg, min(currentset))
-    return [] if target is None else [target]
 
 
 _IN_PLACE_MUTATION_METHODS = frozenset(

--- a/src/eegprep/functions/adminfunc/eeg_retrieve.py
+++ b/src/eegprep/functions/adminfunc/eeg_retrieve.py
@@ -19,16 +19,25 @@ def eeg_retrieve(
         indices = [int(item) for item in index]
         datasets = [dataset_with_loaded_data(_dataset_at(alleeg, item)) for item in indices]
         for item, dataset in zip(indices, datasets):
-            if 1 <= item <= len(alleeg):
+            if _is_occupied(alleeg, item):
                 alleeg[item - 1] = deepcopy(dataset)
         offload_storedisk_datasets(alleeg, set(indices))
         return datasets, alleeg, indices
     current = int(index)
     dataset = dataset_with_loaded_data(_dataset_at(alleeg, current))
-    if 1 <= current <= len(alleeg):
+    if _is_occupied(alleeg, current):
         alleeg[current - 1] = deepcopy(dataset)
     offload_storedisk_datasets(alleeg, {current})
     return dataset, alleeg, current
+
+
+def _is_occupied(alleeg: list[dict[str, Any]], index: int) -> bool:
+    """Return whether ``index`` addresses a dataset rather than a deleted (empty) slot.
+
+    Retrieving a deleted slot yields ``eeg_emptyset()``; writing that back would turn the
+    empty slot into a real dataset and resurrect it in the Datasets menu.
+    """
+    return 1 <= index <= len(alleeg) and bool(alleeg[index - 1])
 
 
 def _dataset_at(alleeg: list[dict[str, Any]], index: int) -> dict[str, Any]:

--- a/src/eegprep/functions/adminfunc/eeg_store.py
+++ b/src/eegprep/functions/adminfunc/eeg_store.py
@@ -11,6 +11,10 @@ from eegprep.functions.adminfunc.storage import offload_storedisk_datasets
 
 def _normalize_index(index: int | None, alleeg: list[dict[str, Any]]) -> int:
     if index is None or index == 0:
+        # EEGLAB stores a new dataset in the lowest empty slot (here ``{}``) before appending.
+        for position, dataset in enumerate(alleeg, start=1):
+            if not dataset:
+                return position
         return len(alleeg) + 1
     if index < 1:
         raise ValueError("EEGLAB dataset indices are 1-based")

--- a/src/eegprep/functions/adminfunc/pop_delset.py
+++ b/src/eegprep/functions/adminfunc/pop_delset.py
@@ -9,16 +9,20 @@ def pop_delset(
     ALLEEG: list[dict[str, Any]] | None,
     indices: int | list[int] | tuple[int, ...],
 ) -> tuple[list[dict[str, Any]], str]:
-    """Delete dataset indices from ``ALLEEG`` and return a history command."""
+    """Delete datasets from ``ALLEEG`` and return a history command.
+
+    Like EEGLAB, each deleted slot is emptied in place (an empty slot is ``{}``) so
+    the remaining datasets keep their numbers; trailing empty slots are dropped.
+    """
     alleeg = [] if ALLEEG is None else list(ALLEEG)
-    if isinstance(indices, int):
-        delete_indices = [int(indices)]
-    else:
-        delete_indices = [int(index) for index in indices]
-    for index in sorted(set(delete_indices), reverse=True):
+    delete_indices = [int(indices)] if isinstance(indices, int) else [int(index) for index in indices]
+    for index in set(delete_indices):
         if index < 1:
             raise ValueError("EEGLAB dataset indices are 1-based")
-        if index <= len(alleeg):
-            del alleeg[index - 1]
+        if index > len(alleeg):
+            raise IndexError(f"No dataset at EEGLAB index {index}")
+        alleeg[index - 1] = {}
+    while alleeg and not alleeg[-1]:
+        alleeg.pop()
     command = f"ALLEEG = pop_delset( ALLEEG, {delete_indices} );"
     return alleeg, command

--- a/src/eegprep/functions/guifunc/main_window.py
+++ b/src/eegprep/functions/guifunc/main_window.py
@@ -354,6 +354,8 @@ def _summary_for_session(session: EEGPrepSession) -> tuple[str, str, list[tuple[
     eeg = session.current_eeg()
     if session.CURRENTSTUDY == 1 and session.STUDY:
         study = session.STUDY
+        # Deleted datasets leave empty ALLEEG slots; they are not datasets of the STUDY.
+        datasets = [dataset for dataset in session.ALLEEG if dataset]
         return (
             f"STUDY set: {study.get('name', '')}",
             _short_file_line("Study filename", study.get("filepath", ""), study.get("filename", "")),
@@ -363,12 +365,12 @@ def _summary_for_session(session: EEGPrepSession) -> tuple[str, str, list[tuple[
                 ("Nb of conditions", _per_subject_count(study.get("condition", []) or [])),
                 ("Nb of sessions", _per_subject_count(study.get("session", []) or [])),
                 ("Nb of groups", _per_subject_count(study.get("group", []) or [])),
-                ("Epoch consistency", _epoch_consistency(session.ALLEEG)),
-                ("Channels per frame", _unique_values(session.ALLEEG, "nbchan")),
-                ("Channel locations", _study_channel_locations(session.ALLEEG)),
+                ("Epoch consistency", _epoch_consistency(datasets)),
+                ("Channels per frame", _unique_values(datasets, "nbchan")),
+                ("Channel locations", _study_channel_locations(datasets)),
                 ("Clusters", str(len(study.get("cluster", []) or []))),
-                ("Status", _study_status(session.ALLEEG)),
-                ("Total size (Mb)", _size_mb(session.ALLEEG)),
+                ("Status", _study_status(datasets)),
+                ("Total size (Mb)", _size_mb(datasets)),
             ],
         )
     if isinstance(eeg, list) and len(eeg) > 1:

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -714,11 +714,14 @@ class MenuActionDispatcher:
                 return
             from eegprep.functions.studyfunc.pop_studydesign import pop_studydesign
 
-            study, alleeg, command = pop_studydesign(self.session.STUDY, self.session.ALLEEG, gui=True, return_com=True)
+            study, _alleeg, command = pop_studydesign(
+                self.session.STUDY, self.session.ALLEEG, gui=True, return_com=True
+            )
             if not command:
                 return
             self.session.echo_command(command)
-            self.session.set_study(study, alleeg, command=command)
+            # EEGLAB's cb_studydesign forces ALLEEGTMP = ALLEEG and e_plot_study discards it.
+            self.session.set_study(study, command=command)
             self._refresh()
             return
         if action == "pop_preclust":
@@ -727,11 +730,12 @@ class MenuActionDispatcher:
                 return
             from eegprep.functions.studyfunc.pop_preclust import pop_preclust
 
-            study, alleeg, command = pop_preclust(self.session.STUDY, self.session.ALLEEG, gui=True, return_com=True)
+            study, _alleeg, command = pop_preclust(self.session.STUDY, self.session.ALLEEG, gui=True, return_com=True)
             if not command:
                 return
             self.session.echo_command(command)
-            self.session.set_study(study, alleeg, command=command)
+            # EEGLAB's e_plot_study clears ALLEEGTMP, so preclustering leaves ALLEEG alone.
+            self.session.set_study(study, command=command)
             self._refresh()
             return
         if action == "pop_precomp":
@@ -741,13 +745,14 @@ class MenuActionDispatcher:
             from eegprep.functions.studyfunc.pop_precomp import pop_precomp
 
             target = "components" if variant == "components" else "channels"
-            study, alleeg, command = pop_precomp(
+            study, _alleeg, command = pop_precomp(
                 self.session.STUDY, self.session.ALLEEG, target, gui=True, return_com=True
             )
             if not command:
                 return
             self.session.echo_command(command)
-            self.session.set_study(study, alleeg, command=command)
+            # EEGLAB's e_plot_study clears ALLEEGTMP, so precomputing leaves ALLEEG alone.
+            self.session.set_study(study, command=command)
             self._refresh()
             return
         if action == "pop_clust":
@@ -1437,7 +1442,8 @@ class MenuActionDispatcher:
         self._refresh()
 
     def _merge_datasets(self, parent: Any | None) -> None:
-        if len(self.session.ALLEEG) < 2:
+        # Deleted datasets leave empty ALLEEG slots, so count real datasets rather than slots.
+        if len(self.session.dataset_summaries()) < 2:
             self._warn(parent, "Load at least two datasets before merging")
             return
         from eegprep.functions.popfunc.pop_mergeset import pop_mergeset

--- a/src/eegprep/functions/guifunc/qt.py
+++ b/src/eegprep/functions/guifunc/qt.py
@@ -1280,7 +1280,7 @@ def _select_interp_channels(button: Any, target: Any, params: Mapping[str, Any])
     )
     if not accepted:
         return
-    if dataset_index < 1 or dataset_index > len(alleeg):
+    if dataset_index < 1 or dataset_index > len(alleeg) or not alleeg[dataset_index - 1]:  # {} = deleted slot
         qt_widgets.QMessageBox.warning(button, "Warning", "Wrong index")
         return
 

--- a/src/eegprep/functions/guifunc/session.py
+++ b/src/eegprep/functions/guifunc/session.py
@@ -91,6 +91,41 @@ def nearest_dataset_index(alleeg: list[Any], anchor: int) -> int | None:
     return above[0] if above else remaining[-1]
 
 
+def _occupied_selection(alleeg: list[Any], selection: list[int]) -> list[int]:
+    """Drop selected indices that address a deleted (empty) slot, re-anchoring if none survive.
+
+    EEGLAB's redraw refuses to leave the selection on an emptied slot
+    (``eeglab.m`` tests ``isempty(ALLEEG(CURRENTSET(1)).data)``) and falls back to a
+    remaining dataset instead of handing the caller an empty EEG.
+    """
+    occupied = [index for index in selection if alleeg[index - 1]]
+    if occupied:
+        return occupied
+    target = nearest_dataset_index(alleeg, min(selection))
+    return [] if target is None else [target]
+
+
+def follow_dataset_selection(alleeg: list[Any], previous_eeg: Any, selection: list[int]) -> list[int]:
+    """Return the dataset selection to use after ``ALLEEG`` was replaced.
+
+    Previously selected datasets are matched by identity first, so a compacted or
+    reordered ``ALLEEG`` keeps the same datasets selected instead of the same numbers.
+    Otherwise the still-occupied numbers are kept, and failing that the nearest
+    remaining dataset is selected.
+    """
+    previous = previous_eeg if isinstance(previous_eeg, list) else [previous_eeg]
+    followed = [index + 1 for index, dataset in enumerate(alleeg) if any(dataset is item for item in previous)]
+    if followed:
+        return followed
+    if not selection:
+        return []
+    in_range = [index for index in selection if index <= len(alleeg)]
+    if in_range:
+        return _occupied_selection(alleeg, in_range)
+    target = nearest_dataset_index(alleeg, min(selection))
+    return [] if target is None else [target]
+
+
 @dataclass
 class EEGPrepSession:
     """EEGLAB-like GUI state without module globals."""
@@ -261,6 +296,8 @@ class EEGPrepSession:
             )
             if resolved_currentset and max(resolved_currentset) > len(resolved_alleeg):
                 raise ValueError("CURRENTSET contains indices outside ALLEEG")
+            if eeg is _UNSET and resolved_currentset:
+                resolved_currentset = _occupied_selection(resolved_alleeg, resolved_currentset)
             resolved_eeg = self._resolve_workspace_eeg(eeg, resolved_alleeg, resolved_currentset)
             current = resolved_eeg if isinstance(resolved_eeg, list) else [resolved_eeg]
             if resolved_currentset and len(current) != len(resolved_currentset):
@@ -333,15 +370,18 @@ class EEGPrepSession:
         self.STUDY = study
         self.CURRENTSTUDY = 1 if study else 0
         if alleeg is not None:
+            previous_eeg = self.EEG
+            previous_selection = list(self.CURRENTSET)
             self.ALLEEG = alleeg
-            if self.ALLEEG and (not self.CURRENTSET or max(self.CURRENTSET) > len(self.ALLEEG)):
-                self.CURRENTSET = [1]
-                self.EEG = self.ALLEEG[0]
-            elif self.ALLEEG and self.CURRENTSET:
+            # STUDY functions return a compacted ALLEEG, so follow the selected datasets
+            # rather than reusing their old numbers.
+            self.CURRENTSET = follow_dataset_selection(self.ALLEEG, previous_eeg, previous_selection)
+            if not self.CURRENTSET and self.ALLEEG:
+                self.CURRENTSET = [index for index, dataset in enumerate(self.ALLEEG, start=1) if dataset][:1]
+            if self.CURRENTSET:
                 selected = [self.ALLEEG[index - 1] for index in self.CURRENTSET]
                 self.EEG = selected if len(selected) > 1 else selected[0]
-            elif not self.ALLEEG:
-                self.CURRENTSET = []
+            else:
                 self.EEG = eeg_emptyset()
             offload_storedisk_datasets(self.ALLEEG, set(self.CURRENTSET))
         self.add_history(command, notify=False)

--- a/src/eegprep/functions/guifunc/session.py
+++ b/src/eegprep/functions/guifunc/session.py
@@ -82,6 +82,15 @@ def normalize_dataset_indices(indices: Any, *, allow_empty: bool = True) -> list
     return normalized
 
 
+def nearest_dataset_index(alleeg: list[Any], anchor: int) -> int | None:
+    """Return the first dataset number at or above ``anchor`` whose slot is not empty, else the last one below."""
+    remaining = [index for index, dataset in enumerate(alleeg, start=1) if dataset]
+    if not remaining:
+        return None
+    above = [index for index in remaining if index >= anchor]
+    return above[0] if above else remaining[-1]
+
+
 @dataclass
 class EEGPrepSession:
     """EEGLAB-like GUI state without module globals."""
@@ -286,14 +295,19 @@ class EEGPrepSession:
         self.notify_changed()
 
     def delete_current(self) -> None:
-        """Delete the current dataset selection from memory."""
+        """Delete the current dataset selection from memory.
+
+        Deleted slots stay empty so the other datasets keep their numbers, as in
+        EEGLAB; the selection moves to the nearest remaining dataset.
+        """
         if not self.CURRENTSET:
             return
         deleted_indices = list(self.CURRENTSET)
         self.ALLEEG, command = pop_delset(self.ALLEEG, self.CURRENTSET)
         self.add_history(command, notify=False)
-        if self.ALLEEG:
-            self.retrieve(min(min(deleted_indices), len(self.ALLEEG)))
+        target = nearest_dataset_index(self.ALLEEG, min(deleted_indices))
+        if target is not None:
+            self.retrieve(target)
             return
         self.CURRENTSET = []
         self.EEG = eeg_emptyset()

--- a/src/eegprep/functions/popfunc/pop_interp.py
+++ b/src/eegprep/functions/popfunc/pop_interp.py
@@ -248,8 +248,10 @@ def _warn_gui_interpolation() -> None:
 
 
 def _alleeg_chanlocs(alleeg: list[dict] | None) -> tuple[dict[str, Any], ...]:
+    # A deleted dataset stays an empty slot; keep it empty so the dialog can reject its number.
     return tuple(
-        {"chanlocs": tuple(copy.deepcopy(_chanlocs_as_list(dataset.get("chanlocs", []))))} for dataset in (alleeg or [])
+        {"chanlocs": tuple(copy.deepcopy(_chanlocs_as_list(dataset.get("chanlocs", []))))} if dataset else {}
+        for dataset in (alleeg or [])
     )
 
 

--- a/src/eegprep/functions/popfunc/pop_mergeset.py
+++ b/src/eegprep/functions/popfunc/pop_mergeset.py
@@ -111,7 +111,9 @@ def _run_gui(
 
 def _default_indices_text(ALLEEG: list[dict[str, Any]], default_indices: Any) -> str:
     if default_indices is None:
-        return " ".join(str(index) for index in range(1, min(len(ALLEEG), 2) + 1)) or "1"
+        # Deleted datasets leave empty slots; offer real dataset numbers only.
+        datasets = [index for index, dataset in enumerate(ALLEEG, start=1) if dataset]
+        return " ".join(str(index) for index in datasets[:2]) or "1"
     return " ".join(str(index) for index in normalize_dataset_indices(default_indices, allow_empty=False))
 
 

--- a/src/eegprep/functions/studyfunc/_study_utils.py
+++ b/src/eegprep/functions/studyfunc/_study_utils.py
@@ -70,8 +70,10 @@ MEASURE_Y_AXIS_FIELDS = {"ersp": "erspfreqs", "itc": "itcfreqs"}
 def as_alleeg_list(ALLEEG: Any) -> list[dict[str, Any]]:
     """Return ``ALLEEG`` as a list of EEG dictionaries without deleted (empty) slots.
 
-    EEGLAB's ``std_editset`` compacts empty datasets the same way, so STUDY dataset
-    numbers stay contiguous when the workspace has gaps.
+    A STUDY needs contiguous dataset numbers, so deleted slots are compacted away here.
+    EEGLAB's ``std_editset`` also removes blank datasets and renumbers
+    ``datasetinfo.index``, though it keys the removal on both the dataset and its
+    ``datasetinfo`` entry being empty.
     """
     if ALLEEG is None:
         return []

--- a/src/eegprep/functions/studyfunc/_study_utils.py
+++ b/src/eegprep/functions/studyfunc/_study_utils.py
@@ -68,14 +68,18 @@ MEASURE_Y_AXIS_FIELDS = {"ersp": "erspfreqs", "itc": "itcfreqs"}
 
 
 def as_alleeg_list(ALLEEG: Any) -> list[dict[str, Any]]:
-    """Return ``ALLEEG`` as a list of EEG dictionaries."""
+    """Return ``ALLEEG`` as a list of EEG dictionaries without deleted (empty) slots.
+
+    EEGLAB's ``std_editset`` compacts empty datasets the same way, so STUDY dataset
+    numbers stay contiguous when the workspace has gaps.
+    """
     if ALLEEG is None:
         return []
     if isinstance(ALLEEG, dict):
         return [ALLEEG]
     if not isinstance(ALLEEG, list) or not all(isinstance(item, dict) for item in ALLEEG):
         raise TypeError("ALLEEG must be a list of EEG dataset dictionaries")
-    return list(ALLEEG)
+    return [item for item in ALLEEG if item]
 
 
 def merged_chanlocs(datasets: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/src/eegprep/resources/help/pop_delset.md
+++ b/src/eegprep/resources/help/pop_delset.md
@@ -1,6 +1,6 @@
 # POP_DELSET - Delete datasets from ALLEEG
 
-`pop_delset` removes one or more datasets from the loaded `ALLEEG` list.
+`pop_delset` deletes one or more datasets from the loaded `ALLEEG` list.
 
 Usage:
 
@@ -9,9 +9,18 @@ ALLEEG, com = pop_delset(ALLEEG, 2)
 ALLEEG, com = pop_delset(ALLEEG, [1, 3])
 ```
 
-Dataset indices are EEGLAB-style 1-based values. The main-window
-"Clear dataset(s)" and "Delete dataset(s) from memory" actions use the shared
-session helpers so `EEG`, `ALLEEG`, and `CURRENTSET` stay synchronized with the
-console.
+Dataset indices are EEGLAB-style 1-based values.
+
+Deleting empties the dataset's slot in place instead of shifting the later
+datasets down, so the remaining dataset numbers stay valid in the Datasets menu,
+in `CURRENTSET`, and in recorded history commands. Deleting dataset 2 of three
+leaves datasets 1 and 3, and an empty slot at 2. Trailing empty slots are
+dropped, and the next dataset you create fills the lowest empty slot. Asking for
+a dataset number that does not exist raises an error.
+
+The main-window "Clear dataset(s)" and "Delete dataset(s) from memory" actions
+use the shared session helpers so `EEG`, `ALLEEG`, and `CURRENTSET` stay
+synchronized with the console. After a delete the selection moves to the nearest
+remaining dataset.
 
 See also: EEG_STORE, EEG_RETRIEVE

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -243,15 +243,25 @@ def test_console_currentset_reassignment_preserves_both_datasets():
     assert workspace.namespace["EEG"]["setname"] == "second"
 
 
-def test_console_pop_delset_keeps_dataset_numbers_and_moves_selection():
+def _delset_console_session(selected):
+    """Return a session and a console workspace with the real ``pop_delset`` wrapper bound."""
     session = EEGPrepSession()
     for name in ("first", "second", "third"):
         session.store_current(_demo_eeg(name), new=True)
-    workspace = EEGPrepConsoleWorkspace(session, exports={})
-    session.retrieve(2)
+    workspace = EEGPrepConsoleWorkspace(session, exports={"pop_delset": pop_delset})
+    session.retrieve(selected)
+    return session, workspace
 
-    workspace.namespace["ALLEEG"], _command = pop_delset(workspace.namespace["ALLEEG"], [2])
-    workspace.after_execute("ALLEEG, com = pop_delset(ALLEEG, [2])")
+
+def _run_console(workspace, source):
+    exec(source, workspace.namespace)  # noqa: S102 - exercising the console execution path
+    workspace.after_execute(source)
+
+
+def test_console_pop_delset_keeps_dataset_numbers_and_moves_selection():
+    session, workspace = _delset_console_session(2)
+
+    _run_console(workspace, "ALLEEG, com = pop_delset(ALLEEG, [2])")
 
     assert session.ALLEEG[1] == {}  # emptied in place, as in EEGLAB
     assert session.ALLEEG[2]["setname"] == "third"  # dataset 3 keeps its number
@@ -259,6 +269,38 @@ def test_console_pop_delset_keeps_dataset_numbers_and_moves_selection():
     assert session.EEG["setname"] == "third"
     assert workspace.namespace["CURRENTSET"] == 3
     assert [index for index, _label, _selected in session.dataset_summaries()] == [1, 3]
+
+
+def test_console_pop_delset_of_trailing_dataset_trims_without_duplicating():
+    session, workspace = _delset_console_session(3)
+
+    _run_console(workspace, "ALLEEG, com = pop_delset(ALLEEG, [3])")
+
+    # The trimmed list must not be mistaken for a selection of new datasets.
+    assert [eeg["setname"] for eeg in session.ALLEEG] == ["first", "second"]
+    assert session.CURRENTSET == [2]
+    assert session.EEG["setname"] == "second"
+
+
+def test_console_pop_delset_of_other_dataset_keeps_the_selected_one():
+    session, workspace = _delset_console_session(2)
+
+    _run_console(workspace, "ALLEEG, com = pop_delset(ALLEEG, [1])")
+
+    assert session.ALLEEG[0] == {}
+    assert session.CURRENTSET == [2]  # the selected dataset keeps its number
+    assert session.EEG["setname"] == "second"
+
+
+def test_console_currentset_on_deleted_slot_selects_a_remaining_dataset():
+    session, workspace = _delset_console_session(2)
+    _run_console(workspace, "ALLEEG, com = pop_delset(ALLEEG, [2])")
+
+    _run_console(workspace, "CURRENTSET = 2")
+
+    # eeglab redraw refuses to leave the selection on an emptied slot.
+    assert session.CURRENTSET == [3]
+    assert session.EEG["setname"] == "third"
 
 
 def test_console_pop_study_result_updates_shared_study_workspace():

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -27,6 +27,7 @@ from eegprep.extensions import (
 )
 from eegprep.functions.adminfunc import console as console_module
 from eegprep.functions.adminfunc.console import EEGPrepConsoleWorkspace
+from eegprep.functions.adminfunc.pop_delset import pop_delset
 from eegprep.functions.guifunc.menu_actions import MenuActionDispatcher
 from eegprep.functions.guifunc.session import EEGPrepSession
 from eegprep.functions.popfunc.pop_newtimef import pop_newtimef
@@ -240,6 +241,24 @@ def test_console_currentset_reassignment_preserves_both_datasets():
     assert session.ALLEEG[0]["setname"] == "first"
     assert session.ALLEEG[1]["setname"] == "second"
     assert workspace.namespace["EEG"]["setname"] == "second"
+
+
+def test_console_pop_delset_keeps_dataset_numbers_and_moves_selection():
+    session = EEGPrepSession()
+    for name in ("first", "second", "third"):
+        session.store_current(_demo_eeg(name), new=True)
+    workspace = EEGPrepConsoleWorkspace(session, exports={})
+    session.retrieve(2)
+
+    workspace.namespace["ALLEEG"], _command = pop_delset(workspace.namespace["ALLEEG"], [2])
+    workspace.after_execute("ALLEEG, com = pop_delset(ALLEEG, [2])")
+
+    assert session.ALLEEG[1] == {}  # emptied in place, as in EEGLAB
+    assert session.ALLEEG[2]["setname"] == "third"  # dataset 3 keeps its number
+    assert session.CURRENTSET == [3]
+    assert session.EEG["setname"] == "third"
+    assert workspace.namespace["CURRENTSET"] == 3
+    assert [index for index, _label, _selected in session.dataset_summaries()] == [1, 3]
 
 
 def test_console_pop_study_result_updates_shared_study_workspace():

--- a/tests/test_eeg_retrieve.py
+++ b/tests/test_eeg_retrieve.py
@@ -57,3 +57,23 @@ def test_eeg_retrieve_rejects_zero_and_missing_indices():
         eeg_retrieve([_eeg()], 0)
     with pytest.raises(IndexError, match="No dataset"):
         eeg_retrieve([_eeg()], 2)
+
+
+def test_eeg_retrieve_leaves_a_deleted_slot_empty():
+    # Retrieving a deleted slot yields an empty EEG, but must not turn the slot into a dataset.
+    alleeg = [_eeg(name="first"), {}, _eeg(name="third")]
+
+    selected, alleeg, current = eeg_retrieve(alleeg, 2)
+
+    assert current == 2
+    assert selected["setname"] == ""
+    assert alleeg[1] == {}
+
+
+def test_eeg_retrieve_list_leaves_deleted_slots_empty():
+    alleeg = [_eeg(name="first"), {}, _eeg(name="third")]
+
+    _selected, alleeg, _current = eeg_retrieve(alleeg, [1, 2, 3])
+
+    assert alleeg[1] == {}
+    assert [alleeg[0]["setname"], alleeg[2]["setname"]] == ["first", "third"]

--- a/tests/test_eeg_store.py
+++ b/tests/test_eeg_store.py
@@ -41,6 +41,16 @@ def test_eeg_store_appends_modified_dataset_as_unsaved():
     assert alleeg[0]["saved"] == "no"
 
 
+def test_eeg_store_fills_lowest_empty_slot():
+    # EEGLAB eeg_store puts a new dataset into the first slot whose data is empty.
+    alleeg = [_eeg(name="first"), {}, _eeg(name="third")]
+
+    alleeg, _checked, index = eeg_store(alleeg, _eeg(name="second"), 0)
+
+    assert index == 2
+    assert [eeg["setname"] for eeg in alleeg] == ["first", "second", "third"]
+
+
 def test_eeg_store_preserves_justloaded_dataset_as_saved():
     alleeg, checked, index = eeg_store([], _eeg(saved="justloaded"), 0)
 

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -461,9 +461,32 @@ class EEGPrepSessionTests(unittest.TestCase):
 
         session.delete_current()
 
-        self.assertEqual(session.CURRENTSET, [1])
+        self.assertEqual(session.ALLEEG[0], {})  # emptied in place, as in EEGLAB
+        self.assertEqual(session.CURRENTSET, [2])  # dataset 2 keeps its number
         self.assertEqual(session.EEG["setname"], "second")
         self.assertEqual(session.menu_statuses(), {"continuous_dataset"})
+
+    def test_session_delete_current_keeps_dataset_numbers_and_reuses_slot(self):
+        session = EEGPrepSession()
+        for name in ("first", "second", "third"):
+            eeg = _demo_eeg()
+            eeg["setname"] = name
+            session.store_current(eeg, new=True)
+        session.retrieve(2)
+
+        session.delete_current()
+
+        self.assertEqual(session.ALLEEG[1], {})
+        self.assertEqual(session.ALLEEG[2]["setname"], "third")
+        self.assertEqual(session.CURRENTSET, [3])
+        self.assertEqual([index for index, _label, _selected in session.dataset_summaries()], [1, 3])
+
+        fourth = _demo_eeg()
+        fourth["setname"] = "fourth"
+        session.store_current(fourth, new=True)
+
+        self.assertEqual(session.CURRENTSET, [2])  # new datasets fill the lowest empty slot
+        self.assertEqual(session.ALLEEG[1]["setname"], "fourth")
 
     def test_session_reports_dataset_status_edges(self):
         session = EEGPrepSession()

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -488,6 +488,61 @@ class EEGPrepSessionTests(unittest.TestCase):
         self.assertEqual(session.CURRENTSET, [2])  # new datasets fill the lowest empty slot
         self.assertEqual(session.ALLEEG[1]["setname"], "fourth")
 
+    def test_session_selection_cannot_land_on_a_deleted_slot(self):
+        session = EEGPrepSession()
+        for name in ("first", "second", "third"):
+            eeg = _demo_eeg()
+            eeg["setname"] = name
+            session.store_current(eeg, new=True)
+        session.retrieve(2)
+        session.delete_current()
+
+        session.apply_workspace_state(currentset=2)
+
+        # eeglab redraw refuses to leave the selection on an emptied slot.
+        self.assertEqual(session.CURRENTSET, [3])
+        self.assertEqual(session.EEG["setname"], "third")
+
+    def test_session_study_action_keeps_the_selected_dataset(self):
+        from eegprep.functions.studyfunc.pop_study import pop_study
+
+        session = EEGPrepSession()
+        for index, name in enumerate(("first", "second", "third"), start=1):
+            eeg = _demo_eeg()
+            eeg["setname"] = name
+            eeg["subject"] = f"S0{index}"
+            session.store_current(eeg, new=True)
+        session.retrieve(2)
+        session.delete_current()
+        self.assertEqual(session.EEG["setname"], "third")
+
+        study, alleeg = pop_study(None, session.ALLEEG, name="Gaps")
+        session.set_study(study, alleeg)
+
+        # A STUDY needs contiguous numbers, so the workspace compacts, but the
+        # selection follows the dataset it was on rather than its old number.
+        self.assertEqual([eeg["setname"] for eeg in session.ALLEEG], ["first", "third"])
+        self.assertEqual(session.EEG["setname"], "third")
+        self.assertEqual(session.CURRENTSET, [2])
+
+    def test_session_summary_handles_a_deleted_slot_in_study_mode(self):
+        from eegprep.functions.guifunc.main_window import _summary_for_session
+
+        session = EEGPrepSession()
+        for name in ("first", "second"):
+            eeg = _demo_eeg()
+            eeg["setname"] = name
+            session.store_current(eeg, new=True)
+        session.retrieve(1)
+        session.delete_current()
+        session.STUDY = {"name": "demo", "datasetinfo": []}
+        session.CURRENTSTUDY = 1
+
+        _title, _subtitle, rows = _summary_for_session(session)
+
+        # The emptied slot is not a dataset, so it must not reach the summary helpers.
+        self.assertEqual(dict(rows)["Channels per frame"], str(session.ALLEEG[1]["nbchan"]))
+
     def test_session_reports_dataset_status_edges(self):
         session = EEGPrepSession()
         session.EEG = _demo_eeg(chanlocs=False, ica=False)
@@ -556,6 +611,23 @@ class MenuActionDispatcherTests(unittest.TestCase):
             dispatcher.dispatch_gui("pop_adjustevents", parent="window")
 
         warn.assert_called_once_with("window", "bad input")
+
+    def test_merge_datasets_warns_when_only_one_dataset_survives_a_delete(self):
+        session = EEGPrepSession()
+        for name in ("first", "second"):
+            eeg = _demo_eeg()
+            eeg["setname"] = name
+            session.store_current(eeg, new=True)
+        session.retrieve(1)
+        session.delete_current()
+        dispatcher = MenuActionDispatcher(session)
+
+        with mock.patch.object(dispatcher, "_warn") as warn:
+            dispatcher._merge_datasets("window")
+
+        # ALLEEG still has two slots, but one of them is an emptied slot, not a dataset.
+        self.assertEqual(len(session.ALLEEG), 2)
+        warn.assert_called_once_with("window", "Load at least two datasets before merging")
 
     def test_show_help_missing_resource_raises_clear_error_not_coming_soon(self):
         dispatcher = MenuActionDispatcher(EEGPrepSession())

--- a/tests/test_phase1b_file_edit_pop_functions.py
+++ b/tests/test_phase1b_file_edit_pop_functions.py
@@ -586,3 +586,12 @@ def test_pop_mergeset_matches_eeglab_for_continuous_event_offsets():
         [float(event["latency"]) for event in py_out["event"]],
         [float(event["latency"]) for event in matlab_out["event"]],
     )
+
+
+def test_pop_mergeset_default_indices_skip_deleted_slots():
+    from eegprep.functions.popfunc.pop_mergeset import _default_indices_text
+
+    # Deleted datasets leave empty ALLEEG slots; the dialog must offer real dataset numbers.
+    assert _default_indices_text([_eeg("first"), {}, _eeg("third")], None) == "1 3"
+    assert _default_indices_text([{}, _eeg("second")], None) == "2"
+    assert _default_indices_text([_eeg("only"), {}], None) == "1"

--- a/tests/test_pop_delset.py
+++ b/tests/test_pop_delset.py
@@ -14,8 +14,22 @@ def test_pop_delset_rejects_non_positive_indices():
         pop_delset([_eeg()], 0)
 
 
-def test_pop_delset_deletes_unique_indices_in_reverse_order():
+def test_pop_delset_rejects_missing_dataset():
+    with pytest.raises(IndexError, match="No dataset at EEGLAB index 2"):
+        pop_delset([_eeg()], 2)
+
+
+def test_pop_delset_empties_slots_in_place_and_drops_trailing_empties():
+    # EEGLAB pop_delset blanks the slot, so dataset 2 keeps its number; the emptied
+    # last slot is dropped like `eeglab redraw` does.
     alleeg, command = pop_delset([_eeg(name="first"), _eeg(name="second"), _eeg(name="third")], [1, 3, 3])
 
-    assert [eeg["setname"] for eeg in alleeg] == ["second"]
+    assert [eeg.get("setname") for eeg in alleeg] == [None, "second"]
+    assert alleeg[0] == {}
     assert command == "ALLEEG = pop_delset( ALLEEG, [1, 3, 3] );"
+
+
+def test_pop_delset_of_only_dataset_leaves_empty_list():
+    alleeg, _command = pop_delset([_eeg()], 1)
+
+    assert alleeg == []

--- a/tests/test_pop_interp.py
+++ b/tests/test_pop_interp.py
@@ -243,6 +243,15 @@ class PopInterpGuiSpecTests(unittest.TestCase):
         self.assertEqual(tuple(alleeg[0]), ("chanlocs",))
         self.assertEqual(alleeg[0]["chanlocs"][0]["labels"], "Ch1")
 
+    def test_other_dataset_callbacks_keep_deleted_slots_empty(self):
+        controls = controls_by_tag(pop_interp_dialog_spec(_eeg(), alleeg=[_eeg(), {}, _eeg()]))
+
+        alleeg = controls["interp_uselist"].callback.params["alleeg"]
+
+        # A deleted dataset stays falsy so the dialog can reject its number.
+        self.assertEqual(alleeg[1], {})
+        self.assertEqual(alleeg[0]["chanlocs"][0]["labels"], "Ch1")
+
     def test_renderer_stores_interp_selection_as_inputgui_userdata(self):
         class Target:
             def __init__(self):

--- a/tests/test_study_metadata.py
+++ b/tests/test_study_metadata.py
@@ -66,6 +66,15 @@ def test_pop_study_history_preserves_requested_design_name():
     assert "design='ERP'" in command
 
 
+def test_pop_study_skips_empty_alleeg_slots():
+    # A deleted dataset leaves an empty ALLEEG slot; STUDY numbering compacts like std_editset.
+    study, alleeg = pop_study(None, [_eeg("one", subject="S01"), {}, _eeg("three", subject="S03")], name="Gaps")
+
+    assert [info["setname"] for info in study["datasetinfo"]] == ["one", "three"]
+    assert [info["index"] for info in study["datasetinfo"]] == [1, 2]
+    assert [eeg["setname"] for eeg in alleeg] == ["one", "three"]
+
+
 def test_std_editset_updates_datasetinfo_and_loaded_dataset_metadata():
     study, alleeg = pop_study(None, [_eeg("one")], name="Initial")
 


### PR DESCRIPTION
🤖 Match EEGLAB's dataset deletion model: deleting a dataset empties its `ALLEEG` slot instead of shifting the later datasets down, so dataset numbers stay valid.

## Problem

In EEGLAB a dataset number is an identity: it appears in the Datasets menu label, in `CURRENTSET`, and in history such as `pop_newset(..., 'retrieve', 3)` or `pop_delset(ALLEEG, [2])`. EEGPrep's `pop_delset` deleted the list entry, so deleting dataset 2 silently renamed datasets 3 and above. A user picking "Dataset 3" from the menu, typing `eeg_retrieve(ALLEEG, 3)` from EEGLAB habit, or re-running a recorded command got a different dataset than EEGLAB would give, and every removal needed re-targeting logic that EEGLAB does not need. The behavior was never documented as a decision (introduced in "Add EEGLAB-style main window menus" with no rationale).

## Reference behavior (vendored EEGLAB)

- `pop_delset.m`: `ALLSET(i) = struct(fields{:})` empties the slot in place; no shift.
- `eeg_store.m`: with `storeSetIndex` 0 or absent, stores into the first slot whose `.data` is empty, otherwise appends.
- `eeglab.m` redraw: trims trailing empty datasets, lists only non-empty slots in the Datasets menu while keeping their numbers, and resets `CURRENTSET` to 1 only when it exceeds the array.
- `std_editset.m`: compacts empty datasets and renumbers `datasetinfo.index`, so STUDY numbering is contiguous.

## Changes

An empty slot is an empty dict `{}`, the convention `eeg_store` (padding), `eeg_retrieve`, and `dataset_summaries` already used.

- `adminfunc/pop_delset.py`: empties each deleted slot in place, drops trailing empty slots (as `eeglab redraw` does), and raises `IndexError` for a dataset number that does not exist (EEGLAB errors with "no such dataset"; previously ignored silently). History string unchanged.
- `adminfunc/eeg_store.py`: index 0/None stores into the lowest empty slot before appending (`eeg_store.m`). `pop_newset` and `EEGPrepSession.store_current(new=True)` inherit this.
- `guifunc/session.py`: new `nearest_dataset_index`; `delete_current` re-selects the first remaining dataset above the lowest deleted number, else the last one below. (EEGLAB leaves `CURRENTSET` on the emptied slot and shows an empty dataset; moving to a neighbour is the friendlier choice and matches what `delete_current` did before.)
- `adminfunc/console.py`: `_currentset_after_alleeg_change` treats an emptied slot as invalid and falls back to the nearest remaining dataset, so `ALLEEG, com = pop_delset(ALLEEG, [2])` in the console moves the selection like the GUI does.
- `guifunc/qt.py`: the "Choose dataset" prompt of the interpolation dialog rejects an emptied slot as "Wrong index".
- `studyfunc/_study_utils.as_alleeg_list`: drops empty slots, so `pop_study` / `std_editset` compact like `std_editset.m` and STUDY dataset numbers stay contiguous.
- Docs: concepts page rule, changelog bullet, the dataset-management example now deletes dataset 2 and prints the surviving numbers, data-structures example sentence on `eeg_store`.

## Tests

- `test_pop_delset.py`: in-place emptying with trailing trim, missing-index error, deleting the only dataset gives `[]`.
- `test_eeg_store.py`: new datasets fill the lowest empty slot.
- `test_gui_main_window.py`: `delete_current` keeps numbers (`CURRENTSET` becomes `[2]` after deleting dataset 1 of 2) and a store after deletion reuses the slot.
- `test_console_workspace.py`: console `pop_delset` round trip keeps dataset 3 at number 3 and moves the selection.
- `test_study_metadata.py`: `pop_study` skips empty slots and renumbers `datasetinfo.index`.

## Verification

```
QT_QPA_PLATFORM=offscreen EEGPREP_SKIP_MATLAB=1 pytest tests/test_pop_delset.py tests/test_eeg_store.py \
  tests/test_eeg_store_storedisk.py tests/test_eeg_retrieve.py tests/test_pop_newset.py tests/test_session_contracts.py \
  tests/test_gui_main_window.py tests/test_console_workspace.py tests/test_study_metadata.py tests/test_study_end_to_end.py \
  tests/test_sample_data_pop_functions.py tests/test_pop_interp.py tests/test_eeg_emptyset.py tests/test_public_api_examples.py
# 369 passed, 1 skipped (MATLAB); plot_reject_artifacts.py fails locally only because torch is not installed
ruff check / ruff format --check on the changed files: clean; ty check: clean
```
