### PR TITLE
Keep STUDY dataset metadata with its dataset after a delete

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,11 @@ the `GitHub Releases <https://github.com/sccn/eegprep/releases>`_ page.
 Unreleased
 ==========
 
+- Deleting a dataset that belongs to a STUDY no longer shifts its STUDY metadata
+  (subject, condition, group, session, run, and components) onto the following
+  datasets. The deleted dataset's ``datasetinfo`` row is dropped together with its
+  ``ALLEEG`` slot, as EEGLAB's ``std_editset`` does, so ``std_checkset`` and the STUDY
+  editor keep each dataset's metadata with that dataset.
 - Deleting datasets (``pop_delset``, Edit > Delete dataset(s) from memory) now empties
   the slot in place like EEGLAB instead of shifting later datasets down, so dataset
   numbers in the Datasets menu, ``CURRENTSET``, and the history stay valid. ``eeg_store``

--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -106,8 +106,8 @@ Practical rules:
   redraw does.
 * Building a STUDY needs contiguous dataset numbers, so creating or editing one
   compacts the empty slots away and renumbers the remaining datasets. EEGLAB's
-  ``std_editset`` does the same. Your selection follows the dataset it was on
-  rather than the number. Editing a STUDY design, precomputing measures, and
+  ``std_editset`` does the same. Each dataset keeps its own STUDY metadata, and
+  your selection follows the dataset it was on rather than the number. Editing a STUDY design, precomputing measures, and
   preclustering leave ``ALLEEG`` untouched, as in EEGLAB.
 
 Two deliberate differences from EEGLAB:

--- a/src/eegprep/functions/studyfunc/_cluster_utils.py
+++ b/src/eegprep/functions/studyfunc/_cluster_utils.py
@@ -10,9 +10,7 @@ import numpy as np
 
 from eegprep.functions.popfunc.plot_utils import component_maps, python_literal
 from eegprep.functions.studyfunc._study_utils import (
-    as_alleeg_list,
-    ensure_study,
-    sync_datasetinfo,
+    sync_study_datasets,
     unique_preserving_order,
 )
 
@@ -21,10 +19,9 @@ def checked_study_and_datasets(
     STUDY: dict[str, Any] | None, ALLEEG: Any
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Return a STUDY with datasetinfo synchronized to loaded datasets."""
-    datasets = as_alleeg_list(ALLEEG)
+    study, datasets = sync_study_datasets(STUDY, ALLEEG)
     if not datasets:
         raise ValueError("STUDY clustering requires loaded ALLEEG datasets")
-    study = sync_datasetinfo(ensure_study(STUDY), datasets)
     return study, datasets
 
 

--- a/src/eegprep/functions/studyfunc/_study_utils.py
+++ b/src/eegprep/functions/studyfunc/_study_utils.py
@@ -67,21 +67,42 @@ MEASURE_X_AXIS_FIELDS = {"erp": "erptimes", "spec": "specfreqs", "ersp": "erspti
 MEASURE_Y_AXIS_FIELDS = {"ersp": "erspfreqs", "itc": "itcfreqs"}
 
 
-def as_alleeg_list(ALLEEG: Any) -> list[dict[str, Any]]:
-    """Return ``ALLEEG`` as a list of EEG dictionaries without deleted (empty) slots.
-
-    A STUDY needs contiguous dataset numbers, so deleted slots are compacted away here.
-    EEGLAB's ``std_editset`` also removes blank datasets and renumbers
-    ``datasetinfo.index``, though it keys the removal on both the dataset and its
-    ``datasetinfo`` entry being empty.
-    """
+def _alleeg_slots(ALLEEG: Any) -> list[dict[str, Any]]:
+    """Return ``ALLEEG`` as a list of slots, keeping deleted (empty ``{}``) slots in place."""
     if ALLEEG is None:
         return []
     if isinstance(ALLEEG, dict):
         return [ALLEEG]
     if not isinstance(ALLEEG, list) or not all(isinstance(item, dict) for item in ALLEEG):
         raise TypeError("ALLEEG must be a list of EEG dataset dictionaries")
-    return [item for item in ALLEEG if item]
+    return list(ALLEEG)
+
+
+def as_alleeg_list(ALLEEG: Any) -> list[dict[str, Any]]:
+    """Return ``ALLEEG`` as a list of EEG dictionaries without deleted (empty) slots.
+
+    A STUDY needs contiguous dataset numbers, so deleted slots are compacted away here.
+    Use :func:`sync_study_datasets` when ``STUDY.datasetinfo`` must follow the compaction.
+    """
+    return [slot for slot in _alleeg_slots(ALLEEG) if slot]
+
+
+def sync_study_datasets(STUDY: Any, ALLEEG: Any) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Return the STUDY with ``datasetinfo`` synchronized to the loaded datasets.
+
+    A dataset deleted from the workspace leaves an empty ``ALLEEG`` slot. While
+    ``datasetinfo`` still has one row per slot, the row of each deleted slot is dropped
+    together with the slot, so the metadata of the remaining datasets stays with them
+    instead of shifting onto the next dataset. EEGLAB's ``std_editset`` removes the two
+    arrays together the same way.
+    """
+    study = ensure_study(STUDY)
+    slots = _alleeg_slots(ALLEEG)
+    existing = _datasetinfo_list(study.get("datasetinfo"))
+    if len(existing) == len(slots) and not all(slots):
+        study["datasetinfo"] = [info for info, slot in zip(existing, slots) if slot]
+    datasets = [slot for slot in slots if slot]
+    return sync_datasetinfo(study, datasets), datasets
 
 
 def merged_chanlocs(datasets: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/src/eegprep/functions/studyfunc/pop_precomp.py
+++ b/src/eegprep/functions/studyfunc/pop_precomp.py
@@ -8,7 +8,7 @@ from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
 from eegprep.functions.popfunc._pop_utils import is_on, parse_key_value_args
 from eegprep.functions.popfunc.plot_utils import parse_plot_options_text, python_literal
-from eegprep.functions.studyfunc._study_utils import as_alleeg_list, build_python_call, ensure_study
+from eegprep.functions.studyfunc._study_utils import build_python_call, ensure_study
 from eegprep.functions.studyfunc.std_checkset import std_checkset
 from eegprep.functions.studyfunc.std_precomp import std_precomp
 
@@ -24,8 +24,7 @@ def pop_precomp(
     **kwargs: Any,
 ) -> Any:
     """Precompute STUDY channel or component measures."""
-    datasets = as_alleeg_list(ALLEEG)
-    study, datasets = std_checkset(ensure_study(STUDY), datasets)
+    study, datasets = std_checkset(ensure_study(STUDY), ALLEEG)
     options = parse_key_value_args(args, kwargs, lowercase_kwargs=True)
     gui = options.pop("gui", gui)
     use_gui = is_on(gui) if gui is not None else False

--- a/src/eegprep/functions/studyfunc/pop_savestudy.py
+++ b/src/eegprep/functions/studyfunc/pop_savestudy.py
@@ -11,7 +11,7 @@ from eegprep.functions.popfunc._file_io import write_json
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.popfunc.pop_saveset import pop_saveset
-from eegprep.functions.studyfunc._study_utils import as_alleeg_list, build_python_call, ensure_study
+from eegprep.functions.studyfunc._study_utils import build_python_call, ensure_study
 from eegprep.functions.studyfunc.std_checkset import std_checkset
 
 
@@ -42,8 +42,8 @@ def pop_savestudy(
     if resavedatasets not in {"on", "off"}:
         raise ValueError("resavedatasets must be 'on' or 'off'")
 
-    datasets = [deepcopy(eeg) for eeg in as_alleeg_list(EEG)] if EEG is not None else []
-    study, _datasets = std_checkset(ensure_study(STUDY), datasets)
+    study, datasets = std_checkset(ensure_study(STUDY), EEG)
+    datasets = [deepcopy(eeg) for eeg in datasets]
     path = _save_path(study, filename, filepath, savemode=savemode)
     path.parent.mkdir(parents=True, exist_ok=True)
     if resavedatasets == "on":

--- a/src/eegprep/functions/studyfunc/pop_study.py
+++ b/src/eegprep/functions/studyfunc/pop_study.py
@@ -63,7 +63,7 @@ def pop_study(
         raise ValueError("pop_study requires at least one loaded dataset")
     study, datasets, _edit_command = std_editset(
         study,
-        datasets,
+        ALLEEG,
         name=name if name is not None else study.get("name", "EEGPrep study"),
         task=task if task is not None else study.get("task", ""),
         notes=notes if notes is not None else study.get("notes", ""),
@@ -96,8 +96,7 @@ def pop_study(
 def pop_study_dialog_spec(STUDY: dict[str, Any] | None, ALLEEG: list[dict[str, Any]] | None) -> DialogSpec:
     """Return the EEGLAB-like STUDY metadata dialog spec."""
     study = ensure_study(STUDY)
-    datasets = as_alleeg_list(ALLEEG)
-    checked, _datasets = std_checkset(study, datasets)
+    checked, datasets = std_checkset(study, ALLEEG)
     title = (
         "Create a new STUDY set -- pop_study()"
         if not STUDY or not STUDY.get("datasetinfo")

--- a/src/eegprep/functions/studyfunc/pop_studydesign.py
+++ b/src/eegprep/functions/studyfunc/pop_studydesign.py
@@ -8,7 +8,6 @@ from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import CallbackSpec, ControlSpec, DialogSpec
 from eegprep.functions.popfunc._pop_utils import is_on, parse_key_value_args
 from eegprep.functions.studyfunc._study_utils import (
-    as_alleeg_list,
     build_python_call,
     ensure_study,
     parse_design_values,
@@ -29,8 +28,7 @@ def pop_studydesign(
     **kwargs: Any,
 ) -> Any:
     """Edit STUDY designs and select the current design."""
-    datasets = as_alleeg_list(ALLEEG)
-    study, datasets = std_checkset(ensure_study(STUDY), datasets)
+    study, datasets = std_checkset(ensure_study(STUDY), ALLEEG)
     options = parse_key_value_args(args, kwargs, lowercase_kwargs=True)
     gui = options.pop("gui", gui)
     if designind is None:
@@ -59,8 +57,7 @@ def pop_studydesign(
 
 def pop_studydesign_dialog_spec(STUDY: dict[str, Any], ALLEEG: list[dict[str, Any]] | None) -> DialogSpec:
     """Return the EEGLAB-like STUDY design dialog spec."""
-    datasets = as_alleeg_list(ALLEEG)
-    study, _datasets = std_checkset(ensure_study(STUDY), datasets)
+    study, _datasets = std_checkset(ensure_study(STUDY), ALLEEG)
     designs = study.get("design") or []
     current = int(study.get("currentdesign") or 1)
     design = designs[current - 1] if 0 < current <= len(designs) else {}

--- a/src/eegprep/functions/studyfunc/std_checkset.py
+++ b/src/eegprep/functions/studyfunc/std_checkset.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from eegprep.functions.studyfunc._study_utils import as_alleeg_list, ensure_study, store_consistency, sync_datasetinfo
+from eegprep.functions.studyfunc._study_utils import store_consistency, sync_study_datasets
 from eegprep.functions.studyfunc.std_makedesign import std_makedesign
 
 
@@ -15,8 +15,7 @@ def std_checkset(
     return_com: bool = False,
 ) -> Any:
     """Normalize a STUDY dict and refresh dataset/design consistency metadata."""
-    datasets = as_alleeg_list(ALLEEG)
-    study = sync_datasetinfo(ensure_study(STUDY), datasets)
+    study, datasets = sync_study_datasets(STUDY, ALLEEG)
     if not study.get("design") and study.get("datasetinfo"):
         study, _command = std_makedesign(study, datasets, 1, return_com=True)
     elif study.get("design") and not study.get("currentdesign"):
@@ -28,8 +27,7 @@ def std_checkset(
 
 def std_checkdatasetinfo(STUDY: dict[str, Any], ALLEEG: list[dict[str, Any]] | None) -> dict[str, Any]:
     """Return STUDY.datasetinfo consistency checks for loaded datasets."""
-    datasets = as_alleeg_list(ALLEEG)
-    study = sync_datasetinfo(ensure_study(STUDY), datasets)
+    study, datasets = sync_study_datasets(STUDY, ALLEEG)
     if "dataset_consistency" not in study["etc"]["eegprep"]:
         study = store_consistency(study, datasets)
     return study["etc"]["eegprep"]["dataset_consistency"]

--- a/src/eegprep/functions/studyfunc/std_editset.py
+++ b/src/eegprep/functions/studyfunc/std_editset.py
@@ -9,11 +9,10 @@ from typing import Any
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args, parse_numeric_sequence
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.studyfunc._study_utils import (
-    as_alleeg_list,
     build_python_call,
-    ensure_study,
     parse_optional_int_text,
     sync_datasetinfo,
+    sync_study_datasets,
 )
 from eegprep.functions.studyfunc.std_checkset import std_checkset
 
@@ -33,8 +32,8 @@ def std_editset(
     **kwargs: Any,
 ) -> Any:
     """Modify STUDY metadata and datasetinfo entries."""
-    datasets = [deepcopy(eeg) for eeg in as_alleeg_list(ALLEEG)]
-    study = sync_datasetinfo(ensure_study(STUDY), datasets)
+    study, datasets = sync_study_datasets(STUDY, ALLEEG)
+    datasets = [deepcopy(eeg) for eeg in datasets]
     options = parse_key_value_args(args, kwargs, lowercase_kwargs=True)
     name = options.pop("name", name)
     task = options.pop("task", task)

--- a/src/eegprep/functions/studyfunc/std_interp.py
+++ b/src/eegprep/functions/studyfunc/std_interp.py
@@ -11,7 +11,7 @@ from eegprep.functions.popfunc._chanutils import chanlocs_as_list
 from eegprep.functions.popfunc.plot_utils import numeric_vector
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args
 from eegprep.functions.popfunc.eeg_interp import eeg_interp
-from eegprep.functions.studyfunc._study_utils import as_alleeg_list, build_python_call, ensure_study, merged_chanlocs
+from eegprep.functions.studyfunc._study_utils import build_python_call, ensure_study, merged_chanlocs
 from eegprep.functions.studyfunc.std_checkset import std_checkset
 
 
@@ -31,7 +31,7 @@ def std_interp(
     method = str(options.pop("method", method) or "spherical")
     if options:
         raise ValueError(f"Unknown std_interp option(s): {', '.join(sorted(options))}")
-    study, datasets = std_checkset(ensure_study(STUDY), as_alleeg_list(ALLEEG))
+    study, datasets = std_checkset(ensure_study(STUDY), ALLEEG)
     if not datasets:
         raise ValueError("std_interp requires ALLEEG datasets")
     all_locs = merged_chanlocs(datasets)

--- a/src/eegprep/functions/studyfunc/std_makedesign.py
+++ b/src/eegprep/functions/studyfunc/std_makedesign.py
@@ -8,13 +8,11 @@ from typing import Any
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args
 from eegprep.functions.studyfunc._study_utils import (
     _empty_value,
-    as_alleeg_list,
     available_variables,
     build_python_call,
-    ensure_study,
     parse_design_values,
     store_consistency,
-    sync_datasetinfo,
+    sync_study_datasets,
     variable_values,
 )
 from eegprep.functions.studyfunc.std_addvarlevel import std_addvarlevel
@@ -54,8 +52,7 @@ def std_makedesign(
     change, while ``'off'`` preserves any precomputed ``changrp``/``cluster``
     measures attached to the redefined design.
     """
-    datasets = as_alleeg_list(ALLEEG)
-    study = sync_datasetinfo(ensure_study(STUDY), datasets)
+    study, datasets = sync_study_datasets(STUDY, ALLEEG)
     options = parse_key_value_args(args, kwargs, lowercase_kwargs=True)
     name = options.pop("name", name)
     variable1 = options.pop("variable1", variable1)

--- a/src/eegprep/functions/studyfunc/std_maketrialinfo.py
+++ b/src/eegprep/functions/studyfunc/std_maketrialinfo.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import numpy as np
 
-from eegprep.functions.studyfunc._study_utils import as_alleeg_list, ensure_study, sync_datasetinfo, trialinfo_from_eeg
+from eegprep.functions.studyfunc._study_utils import sync_study_datasets, trialinfo_from_eeg
 
 
 EVENT_TRIALINFO_EXCLUDE = {"latency", "urevent", "epoch"}
@@ -18,8 +18,7 @@ def std_maketrialinfo(
     ALLEEG: list[dict[str, Any]] | None,
 ) -> tuple[dict[str, Any], list[list[dict[str, Any]]]]:
     """Populate ``STUDY.datasetinfo[*].trialinfo`` from loaded EEG metadata."""
-    datasets = as_alleeg_list(ALLEEG)
-    study = sync_datasetinfo(ensure_study(STUDY), datasets)
+    study, datasets = sync_study_datasets(STUDY, ALLEEG)
     alltrialinfo: list[list[dict[str, Any]]] = []
     for index, eeg in enumerate(datasets):
         rows = trialinfo_from_eeg(eeg)

--- a/src/eegprep/functions/studyfunc/std_pac.py
+++ b/src/eegprep/functions/studyfunc/std_pac.py
@@ -172,7 +172,7 @@ def _std_pac_study(
     datasets = as_alleeg_list(ALLEEG)
     if not datasets:
         raise ValueError("std_pac STUDY mode requires ALLEEG datasets")
-    study, datasets = std_checkset(ensure_study(STUDY), datasets)
+    study, datasets = std_checkset(ensure_study(STUDY), ALLEEG)
     params = _parameters(datasets[0], freqs, cycles, freqphase, cyclephase, padratio, freqscale, pac_options)
     if is_on(getparams):
         return (

--- a/src/eegprep/functions/studyfunc/std_precomp.py
+++ b/src/eegprep/functions/studyfunc/std_precomp.py
@@ -55,7 +55,7 @@ def std_precomp(
     datasets = as_alleeg_list(ALLEEG)
     if not datasets:
         raise ValueError("std_precomp requires ALLEEG datasets")
-    study, datasets = std_checkset(ensure_study(STUDY), datasets)
+    study, datasets = std_checkset(ensure_study(STUDY), ALLEEG)
     options = parse_key_value_args(args, kwargs, lowercase_kwargs=True)
     erp = options.pop("erp", erp)
     spec = options.pop("spec", spec)

--- a/src/eegprep/functions/studyfunc/std_prepare_neighbors.py
+++ b/src/eegprep/functions/studyfunc/std_prepare_neighbors.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from eegprep.functions.popfunc.plot_utils import numeric_vector
 from eegprep.functions.popfunc._pop_utils import is_on, parse_key_value_args
-from eegprep.functions.studyfunc._study_utils import as_alleeg_list, build_python_call, ensure_study, merged_chanlocs
+from eegprep.functions.studyfunc._study_utils import build_python_call, ensure_study, merged_chanlocs
 from eegprep.functions.studyfunc.std_checkset import std_checkset
 
 
@@ -32,7 +32,7 @@ def std_prepare_neighbors(
     neighbordist = options.pop("neighbordist", neighbordist)
     if options:
         raise ValueError(f"Unknown std_prepare_neighbors option(s): {', '.join(sorted(options))}")
-    study, datasets = std_checkset(ensure_study(STUDY), as_alleeg_list(ALLEEG))
+    study, datasets = std_checkset(ensure_study(STUDY), ALLEEG)
     if not is_on(force) and not _study_requests_neighbors(study):
         neighbors: list[dict[str, Any]] = []
         limostruct = {"expected_chanlocs": [], "channeighbstructmat": np.empty((0, 0), dtype=int)}

--- a/src/eegprep/functions/studyfunc/std_rebuilddesign.py
+++ b/src/eegprep/functions/studyfunc/std_rebuilddesign.py
@@ -6,10 +6,9 @@ from copy import deepcopy
 from typing import Any
 
 from eegprep.functions.studyfunc._study_utils import (
-    as_alleeg_list,
     build_python_call,
     ensure_study,
-    sync_datasetinfo,
+    sync_study_datasets,
     variable_values,
 )
 from eegprep.functions.studyfunc.std_addvarlevel import std_addvarlevel
@@ -23,8 +22,7 @@ def std_rebuilddesign(
     return_com: bool = False,
 ) -> Any:
     """Refresh STUDY design variables after dataset metadata changes."""
-    datasets = as_alleeg_list(ALLEEG)
-    study = sync_datasetinfo(deepcopy(ensure_study(STUDY)), datasets)
+    study, datasets = sync_study_datasets(deepcopy(ensure_study(STUDY)), ALLEEG)
     designs = list(study.get("design") or [])
     indices = range(1, len(designs) + 1) if designind is None else [int(designind)]
     for index in indices:

--- a/src/eegprep/functions/studyfunc/std_rmdat.py
+++ b/src/eegprep/functions/studyfunc/std_rmdat.py
@@ -9,10 +9,8 @@ import numpy as np
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args
 from eegprep.functions.studyfunc._study_utils import (
     _empty_value,
-    as_alleeg_list,
     build_python_call,
-    ensure_study,
-    sync_datasetinfo,
+    sync_study_datasets,
 )
 from eegprep.functions.studyfunc.std_substudy import std_substudy
 
@@ -48,8 +46,7 @@ def std_rmdat(
     keepvarvalues = options.pop("keepvarvalues", keepvarvalues)
     if options:
         raise ValueError(f"Unknown std_rmdat option(s): {', '.join(sorted(options))}")
-    datasets = as_alleeg_list(ALLEEG)
-    study = sync_datasetinfo(ensure_study(STUDY), datasets)
+    study, datasets = sync_study_datasets(STUDY, ALLEEG)
     infos = [info for info in study.get("datasetinfo") or [] if isinstance(info, dict)]
     total = max(len(datasets), len(infos))
     remove = set(_index_values(datinds, total))

--- a/src/eegprep/functions/studyfunc/std_selectdataset.py
+++ b/src/eegprep/functions/studyfunc/std_selectdataset.py
@@ -8,9 +8,7 @@ import numpy as np
 
 from eegprep.functions.studyfunc._study_utils import (
     _empty_value,
-    as_alleeg_list,
-    ensure_study,
-    sync_datasetinfo,
+    sync_study_datasets,
     trialinfo_rows,
 )
 from eegprep.functions.studyfunc.std_indvarmatch import std_indvarmatch
@@ -31,8 +29,7 @@ def std_selectdataset(
     matching trial are returned.
     """
     _ = verboseFlag
-    datasets = as_alleeg_list(ALLEEG)
-    study = sync_datasetinfo(ensure_study(STUDY), datasets)
+    study, datasets = sync_study_datasets(STUDY, ALLEEG)
     infos = [info for info in study.get("datasetinfo") or [] if isinstance(info, dict)]
     trialselect = _all_trials(infos, datasets)
     if _empty_value(indvar):

--- a/src/eegprep/functions/studyfunc/std_substudy.py
+++ b/src/eegprep/functions/studyfunc/std_substudy.py
@@ -11,10 +11,8 @@ from eegprep.functions.popfunc._pop_utils import is_on, parse_key_value_args
 from eegprep.functions.studyfunc._cluster_utils import sets_array
 from eegprep.functions.studyfunc._study_utils import (
     _empty_value,
-    as_alleeg_list,
     build_python_call,
-    ensure_study,
-    sync_datasetinfo,
+    sync_study_datasets,
 )
 from eegprep.functions.studyfunc.std_checkset import std_checkset
 from eegprep.functions.studyfunc.std_rmalldatafields import std_rmalldatafields
@@ -41,8 +39,7 @@ def std_substudy(
     rmdat = options.pop("rmdat", rmdat)
     if options:
         raise ValueError(f"Unknown std_substudy option(s): {', '.join(sorted(options))}")
-    datasets = as_alleeg_list(ALLEEG)
-    study = sync_datasetinfo(ensure_study(STUDY), datasets)
+    study, datasets = sync_study_datasets(STUDY, ALLEEG)
     infos = [info for info in study.get("datasetinfo") or [] if isinstance(info, dict)]
     keep = _kept_dataset_indices(infos, len(datasets), dataset, subject, condition, group)
     if not keep:

--- a/tests/test_study_metadata.py
+++ b/tests/test_study_metadata.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from eegprep.functions.adminfunc.pop_delset import pop_delset
 from eegprep.functions.popfunc.pop_saveset import pop_saveset
 from eegprep.functions.studyfunc.pop_loadstudy import pop_loadstudy
 from eegprep.functions.studyfunc.pop_savestudy import pop_savestudy
@@ -393,3 +394,65 @@ def test_std_findgroupvars_requires_one_unique_value_within_each_subject():
     }
 
     assert std_findgroupvars(study) == ["group"]
+
+
+def test_std_checkset_drops_the_datasetinfo_row_of_a_deleted_dataset():
+    # Deleting a dataset leaves an empty ALLEEG slot. Its STUDY row must go with it instead
+    # of shifting onto the next dataset, as std_editset.m removes both arrays together.
+    study, alleeg = pop_study(
+        None,
+        [
+            _eeg("one", subject="S01", condition="a"),
+            _eeg("two", subject="S02", condition="b"),
+            _eeg("three", subject="S03", condition="c"),
+        ],
+        name="Gaps",
+    )
+    alleeg, _command = pop_delset(alleeg, [2])
+
+    checked, datasets = std_checkset(study, alleeg)
+
+    rows = [(info["index"], info["setname"], info["subject"], info["condition"]) for info in checked["datasetinfo"]]
+    assert rows == [(1, "one", "S01", "a"), (2, "three", "S03", "c")]
+    assert [eeg["setname"] for eeg in datasets] == ["one", "three"]
+
+
+def test_pop_study_edit_keeps_metadata_with_its_dataset_after_a_delete():
+    study, alleeg = pop_study(
+        None,
+        [_eeg("one", subject="S01"), _eeg("two", subject="S02"), _eeg("three", subject="S03")],
+        name="Gaps",
+    )
+    alleeg, _command = pop_delset(alleeg, [1])
+
+    edited, edited_alleeg = pop_study(study, alleeg, name="Edited")
+
+    rows = [(info["index"], info["setname"], info["subject"]) for info in edited["datasetinfo"]]
+    assert rows == [(1, "two", "S02"), (2, "three", "S03")]
+    assert [eeg["setname"] for eeg in edited_alleeg] == ["two", "three"]
+
+
+def test_std_checkset_keeps_positional_rows_when_a_dataset_is_appended():
+    # Without a deleted slot the rows still pair by position, so a new dataset gets a new row.
+    study, alleeg = pop_study(None, [_eeg("one", subject="S01"), _eeg("two", subject="S02")], name="Grow")
+    alleeg.append(_eeg("three"))
+
+    checked, _datasets = std_checkset(study, alleeg)
+
+    rows = [(info["setname"], info["subject"]) for info in checked["datasetinfo"]]
+    assert rows == [("one", "S01"), ("two", "S02"), ("three", "S3")]
+
+
+def test_pop_savestudy_after_a_delete_writes_each_dataset_with_its_own_metadata(tmp_path):
+    study, alleeg = pop_study(
+        None,
+        [_eeg("one", subject="S01"), _eeg("two", subject="S02"), _eeg("three", subject="S03")],
+        name="Gaps",
+    )
+    alleeg, _command = pop_delset(alleeg, [2])
+
+    pop_savestudy(study, alleeg, filename="gaps.study", filepath=tmp_path)
+    reloaded, _alleeg = pop_loadstudy("gaps.study", filepath=tmp_path, load_datasets="off")
+
+    rows = [(info["index"], info["setname"], info["subject"]) for info in reloaded["datasetinfo"]]
+    assert rows == [(1, "one", "S01"), (2, "three", "S03")]


### PR DESCRIPTION
Deleting a dataset leaves an empty ALLEEG slot, but STUDY functions compacted ALLEEG while datasetinfo kept one row per slot, so the metadata of every later dataset shifted onto the wrong dataset and pop_savestudy saved it that way. sync_study_datasets now drops the datasetinfo row of a deleted slot together with the slot, as EEGLAB's std_editset does, and the STUDY wrappers pass the raw ALLEEG through. Adds regression tests including a save and reload round trip.