### PR TITLE
Match EEGLAB's probability loop in pop_autorej

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,14 @@ the `GitHub Releases <https://github.com/sccn/eegprep/releases>`_ page.
 Unreleased
 ==========
 
+- ``pop_autorej`` (Tools > Automatic epoch rejection) now runs EEGLAB's probability loop
+  exactly: a pass rejects its flagged epochs only when they are fewer than ``maxrej``
+  percent of the remaining epochs (5% of 80 epochs is not fewer, so the threshold is
+  raised instead), and once a pass flags nothing the threshold walks back down in
+  0.5 s.d. steps toward 5 s.d. for up to eight pruning rounds instead of stopping at the
+  first clean pass. The final kurtosis pass is applied in channel mode as well; EEGLAB
+  currently skips it there because it reads the component rejection field. Rejected
+  epochs on the epoched sample dataset now match ``tests/matlab/pop_autorej_reference.m``.
 - Deleting datasets (``pop_delset``, Edit > Delete dataset(s) from memory) now empties
   the slot in place like EEGLAB instead of shifting later datasets down, so dataset
   numbers in the Datasets menu, ``CURRENTSET``, and the history stay valid. ``eeg_store``

--- a/src/eegprep/functions/popfunc/pop_autorej.py
+++ b/src/eegprep/functions/popfunc/pop_autorej.py
@@ -22,6 +22,9 @@ from eegprep.functions.popfunc.pop_jointprob import pop_jointprob
 from eegprep.functions.popfunc.pop_rejepoch import pop_rejepoch
 from eegprep.functions.popfunc.pop_rejkurt import pop_rejkurt
 
+DEFAULT_STARTPROB = 5.0  # EEGLAB prunes back toward this value, not toward the requested startprob
+MAX_PRUNING_ROUNDS = 8
+
 
 def pop_autorej(
     EEG: dict[str, Any],
@@ -138,23 +141,35 @@ def _apply_one(
     rows = electrodes if process_data else icacomps
     work = out
     remaining = list(range(1, int(work.get("trials", 1) or 1) + 1))
+    # EEGLAB's loop: a pass rejects its flagged epochs only when they are fewer than
+    # maxrej percent of the remaining epochs, otherwise the threshold rises by 0.5 s.d.
+    # Once a pass flags nothing, the threshold walks back down toward DEFAULT_STARTPROB
+    # for at most MAX_PRUNING_ROUNDS rounds before the loop ends.
     limit = startprob
-    for _iteration in range(12):
-        work, _locthresh, _globthresh, _nrej = pop_jointprob(work, int(process_data), rows, limit, limit, 0, 0)
-        field = "rejjp" if process_data else "icarejjp"
-        marks = np.asarray((work.get("reject") or {}).get(field, []), dtype=bool)
-        current = (np.flatnonzero(marks) + 1).tolist()
-        if not current:
-            break
-        if len(current) / max(1, int(work.get("trials", 1))) <= maxrej / 100:
-            rejected.update(remaining[index - 1] for index in current)
-            work = pop_rejepoch(work, current, 0)
-            drop = set(current)
-            remaining = [value for index, value in enumerate(remaining, start=1) if index not in drop]
-            if int(work.get("trials", 1) or 1) <= 1:
-                break
+    numrej = 1  # forces the first probability pass
+    pruning_rounds = 0
+    while True:
+        if numrej > 0:
+            work, _locthresh, _globthresh, _nrej = pop_jointprob(work, int(process_data), rows, limit, limit, 0, 0)
+            field = "rejjp" if process_data else "icarejjp"
+            marks = np.asarray((work.get("reject") or {}).get(field, []), dtype=bool)
+            current = (np.flatnonzero(marks) + 1).tolist()
+            numrej = len(current)
+            if numrej / int(work.get("trials", 1)) >= maxrej / 100:
+                limit += 0.5
+            elif current:
+                rejected.update(remaining[index - 1] for index in current)
+                work = pop_rejepoch(work, current, 0)
+                drop = set(current)
+                remaining = [value for index, value in enumerate(remaining, start=1) if index not in drop]
+                if int(work.get("trials", 1) or 1) <= 1:
+                    break
+        elif limit > DEFAULT_STARTPROB and pruning_rounds < MAX_PRUNING_ROUNDS:
+            limit -= 0.5
+            numrej = 1
+            pruning_rounds += 1
         else:
-            limit += 0.5
+            break
     if int(work.get("trials", 1) or 1) > 1:
         work, _locthresh, _globthresh, _nrej = pop_rejkurt(work, int(process_data), rows, 6, 6, 0, 0)
         field = "rejkurt" if process_data else "icarejkurt"

--- a/tests/matlab/pop_autorej_reference.m
+++ b/tests/matlab/pop_autorej_reference.m
@@ -1,0 +1,45 @@
+% Reference rejections for tests/test_pop_autorej.py.
+%
+% Runs EEGLAB pop_autorej on sample_data/eeglab_data_epochs_ica.set for each option
+% set below and prints the rejected epoch numbers (sorted; EEGLAB returns them in
+% rejection order).
+%
+% EEGLAB's final kurtosis pass counts EEG.reject.icarejkurt whatever the mode, so for
+% channel-based runs it never rejects anything. The script re-applies that pass with
+% the channel field (EEG.reject.rejkurt) on the returned dataset and reports the
+% combined result, which is what EEGPrep is expected to produce.
+%
+% Run from tests/matlab with an EEGLAB checkout on the path (or the vendored one).
+clear
+addpath(fullfile(pwd, '..', '..', 'src', 'eegprep', 'eeglab'));
+if ~exist('pop_loadset', 'file')
+    eeglab nogui;
+end
+
+EEG = pop_loadset('../../sample_data/eeglab_data_epochs_ica.set');
+ncomp = size(EEG.icaweights, 1);
+cases = { ...
+    'default',             {}; ...
+    'maxrej2p5',           {'maxrej', 2.5}; ...
+    'start3',              {'startprob', 3}; ...
+    'start3_maxrej2p5',    {'startprob', 3, 'maxrej', 2.5}; ...
+    'start4_maxrej2p5',    {'startprob', 4, 'maxrej', 2.5}; ...
+    'maxrej1p25',          {'maxrej', 1.25}; ...
+    'elec1to16_maxrej2p5', {'electrodes', 1:16, 'maxrej', 2.5}; ...
+    'ica_default',         {'icacomps', 1:ncomp}; ...
+    'ica_maxrej2p5',       {'icacomps', 1:ncomp, 'maxrej', 2.5}; ...
+    'ica1to10_maxrej2p5',  {'icacomps', 1:10, 'maxrej', 2.5} };
+
+for i = 1:size(cases, 1)
+    options = cases{i, 2};
+    [EEG2, rmep] = pop_autorej(EEG, 'nogui', 'on', options{:});
+    if ~any(strcmp(options, 'icacomps'))
+        electrodes = 1:EEG.nbchan;
+        idx = find(strcmp(options, 'electrodes'));
+        if ~isempty(idx), electrodes = options{idx+1}; end
+        EEG3 = pop_rejkurt(EEG2, 1, electrodes, 6, 6, 0, 0);
+        remaining = setdiff(1:EEG.trials, rmep);
+        rmep = [rmep remaining(find(EEG3.reject.rejkurt))];
+    end
+    fprintf('REFERENCE %s: %s\n', cases{i, 1}, mat2str(sort(rmep)));
+end

--- a/tests/test_pop_autorej.py
+++ b/tests/test_pop_autorej.py
@@ -1,0 +1,51 @@
+"""MATLAB parity tests for pop_autorej on sample_data/eeglab_data_epochs_ica.set.
+
+Expected epoch numbers come from tests/matlab/pop_autorej_reference.m run with
+MATLAB R2025b against EEGLAB develop aadfd19a7 (pop_autorej.m after the unreachable
+15% branch was removed). Rejected epoch numbers must match exactly; EEGLAB lists
+them in rejection order, EEGPrep sorted. EEGLAB's final kurtosis pass reads the
+component field in channel mode and so never rejects there; the reference script
+re-applies it with the channel field, and EEGPrep applies it in both modes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from eegprep.functions.popfunc.pop_autorej import pop_autorej
+from eegprep.functions.popfunc.pop_loadset import pop_loadset
+
+EPOCHED_DATASET_PATH = Path(__file__).resolve().parents[1] / "sample_data" / "eeglab_data_epochs_ica.set"
+
+# Each case names the loop phases it exercises on the 80-epoch dataset.
+EEGLAB_REJECTIONS = [
+    # 4 of 80 flagged at 5 s.d. is not fewer than 5%: raise to 5.5, reject 4 epochs over two
+    # passes, then one pruning round back at 5 s.d. rejects epoch 28; kurtosis adds 16.
+    pytest.param((), [1, 2, 16, 28, 46, 70], id="default"),
+    # Raise to 6 s.d., reject epoch 70, then eight pruning rounds oscillate 5.5/6 s.d.
+    pytest.param(("maxrej", 2.5), [16, 70], id="maxrej2p5"),
+    # Start below the default: five raises before anything is rejected.
+    pytest.param(("startprob", 3), [1, 2, 16, 28, 46, 70], id="start3"),
+    pytest.param(("startprob", 3, "maxrej", 2.5), [16, 70], id="start3_maxrej2p5"),
+    pytest.param(("startprob", 4, "maxrej", 2.5), [16, 70], id="start4_maxrej2p5"),
+    # 1.25% of 80 epochs means nothing can be rejected; eight pruning rounds then kurtosis.
+    pytest.param(("maxrej", 1.25), [16], id="maxrej1p25"),
+    # Two pruning rounds reach 5 s.d. and stop.
+    pytest.param(("electrodes", list(range(1, 17)), "maxrej", 2.5), [16, 46, 70], id="elec1to16_maxrej2p5"),
+    # Component mode: rejects at 5 s.d. without raising, kurtosis adds two epochs.
+    pytest.param(("icacomps", list(range(1, 33))), [2, 9, 10, 43], id="ica_default"),
+    pytest.param(("icacomps", list(range(1, 33)), "maxrej", 2.5), [9, 10], id="ica_maxrej2p5"),
+    pytest.param(("icacomps", list(range(1, 11)), "maxrej", 2.5), [9], id="ica1to10_maxrej2p5"),
+]
+
+
+@pytest.mark.parametrize(("options", "expected"), EEGLAB_REJECTIONS)
+def test_pop_autorej_rejects_the_same_epochs_as_eeglab(options, expected):
+    EEG = pop_loadset(EPOCHED_DATASET_PATH)
+
+    out, rejected = pop_autorej(EEG, *options, "nogui", "on")
+
+    assert rejected == expected
+    assert out["trials"] == EEG["trials"] - len(expected)


### PR DESCRIPTION
Run the pop_autorej probability loop like EEGLAB: a pass rejects only when fewer than maxrej percent of the epochs are flagged, and once nothing is flagged the threshold walks back toward 5 s.d. for up to eight pruning rounds instead of stopping at the first clean pass. Adds a parity test with reference rejections from tests/matlab/pop_autorej_reference.m (EEGLAB develop aadfd19a7). The final kurtosis pass stays mode-aware; EEGLAB skips it in channel mode because it reads icarejkurt.