### PR TITLE
[newtimef] Return log-scale baseline power in dB and expand parity tests

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,10 @@ the `GitHub Releases <https://github.com/sccn/eegprep/releases>`_ page.
 Unreleased
 ==========
 
+- ``newtimef`` / ``pop_newtimef`` now return the baseline power spectrum (``powbase``) in dB for the
+  default log power scale, matching EEGLAB's ``mbase``; it was previously returned in absolute power.
+  Absolute-scale, ``basenorm``, and ``trialbase`` runs are unchanged (``powbase`` stays in absolute
+  power there, as in EEGLAB), as is the plotted figure.
 - ``pop_newtimef`` / ``newtimef`` now render EEGLAB's single-condition ERSP/ITC time-frequency
   figure. The ERSP and ITC images use a symmetric color axis, a stimulus-onset (time 0) marker,
   right-hand colorbars titled with the power unit, and the ``turbo`` colormap (EEGPrep's house

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,9 @@ Unreleased
 - ``newtimef`` / ``pop_newtimef`` now return the baseline power spectrum (``powbase``) in dB for the
   default log power scale with a baseline, matching EEGLAB's ``mbase``; it was previously returned in
   absolute power. It stays in absolute power for absolute-scale, ``basenorm``, and ``trialbase`` runs
-  and when no baseline is used (as in EEGLAB), and the plotted figure is unchanged.
+  and when no baseline is used (as in EEGLAB), and the plotted figure is unchanged. ``std_precomp``
+  correspondingly caches the STUDY ``erspbase`` field in dB for its default log/baseline settings;
+  rerun precomputation with ``recompute='on'`` to refresh values cached by an earlier version.
 - ``pop_newtimef`` / ``newtimef`` now render EEGLAB's single-condition ERSP/ITC time-frequency
   figure. The ERSP and ITC images use a symmetric color axis, a stimulus-onset (time 0) marker,
   right-hand colorbars titled with the power unit, and the ``turbo`` colormap (EEGPrep's house

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,9 +11,9 @@ Unreleased
 ==========
 
 - ``newtimef`` / ``pop_newtimef`` now return the baseline power spectrum (``powbase``) in dB for the
-  default log power scale, matching EEGLAB's ``mbase``; it was previously returned in absolute power.
-  Absolute-scale, ``basenorm``, and ``trialbase`` runs are unchanged (``powbase`` stays in absolute
-  power there, as in EEGLAB), as is the plotted figure.
+  default log power scale with a baseline, matching EEGLAB's ``mbase``; it was previously returned in
+  absolute power. It stays in absolute power for absolute-scale, ``basenorm``, and ``trialbase`` runs
+  and when no baseline is used (as in EEGLAB), and the plotted figure is unchanged.
 - ``pop_newtimef`` / ``newtimef`` now render EEGLAB's single-condition ERSP/ITC time-frequency
   figure. The ERSP and ITC images use a symmetric color axis, a stimulus-onset (time 0) marker,
   right-hand colorbars titled with the power unit, and the ``turbo`` colormap (EEGPrep's house

--- a/src/eegprep/functions/timefreqfunc/newtimef.py
+++ b/src/eegprep/functions/timefreqfunc/newtimef.py
@@ -32,7 +32,7 @@ class TimeFrequencyResult:
 
     ersp: np.ndarray
     itc: np.ndarray
-    powbase: np.ndarray
+    powbase: np.ndarray  # baseline power spectrum (EEGLAB mbase): dB for log scale, absolute power otherwise
     times: np.ndarray
     freqs: np.ndarray
     tfdata: np.ndarray
@@ -257,10 +257,22 @@ def newtimef(
             elocs=elocs,
             caption=caption,
         )
+    base_vec = _numeric_vector(baseline)
+    baseline_on = base_vec.size > 0 and not np.isnan(base_vec[0])
+    powbase_out = np.asarray(powbase_array, dtype=float)
+    if (
+        scale_mode == "log"
+        and str(trialbase).lower() == "off"
+        and baseline_on
+        and powbase_out.size
+        and np.isfinite(powbase_out.reshape(-1)[0])
+    ):
+        # EEGLAB newtimef.m:1399 returns the baseline power spectrum in dB for log scale (trialbase off).
+        powbase_out = 10.0 * np.log10(powbase_out)
     return TimeFrequencyResult(
         ersp,
         itc,
-        np.asarray(powbase_array).squeeze(),
+        powbase_out.squeeze(),
         decomp.times,
         decomp.freqs,
         tfdata,

--- a/src/eegprep/functions/timefreqfunc/newtimef.py
+++ b/src/eegprep/functions/timefreqfunc/newtimef.py
@@ -32,7 +32,7 @@ class TimeFrequencyResult:
 
     ersp: np.ndarray
     itc: np.ndarray
-    powbase: np.ndarray  # baseline power spectrum (EEGLAB mbase): dB for log scale, absolute power otherwise
+    powbase: np.ndarray  # EEGLAB mbase: dB only with log scale, a baseline, and trialbase off; else absolute power
     times: np.ndarray
     freqs: np.ndarray
     tfdata: np.ndarray
@@ -257,8 +257,10 @@ def newtimef(
             elocs=elocs,
             caption=caption,
         )
-    base_vec = _numeric_vector(baseline)
-    baseline_on = base_vec.size > 0 and not np.isnan(base_vec[0])
+    # Mirror newtimefbaseln's `disabled` check so powbase units always track ersp: a multi-window
+    # (nested-list) baseline flattens cleanly, `[]` stays enabled, and only NaN/None disables.
+    base_vec = np.asarray(baseline, dtype=float).reshape(-1)
+    baseline_on = not (base_vec.size and np.isnan(base_vec[0]))
     powbase_out = np.asarray(powbase_array, dtype=float)
     if (
         scale_mode == "log"

--- a/tests/test_phase4_timefreq_statistics.py
+++ b/tests/test_phase4_timefreq_statistics.py
@@ -223,6 +223,9 @@ def test_newtimef_supplied_powbase_shifts_ersp_by_db_offset():
     base0 = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], powbase=np.zeros(nfreq), **common)
     base3 = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], powbase=np.full(nfreq, 3.0), **common)
     np.testing.assert_allclose(base3.ersp, base0.ersp - 3.0, rtol=1e-6, atol=1e-6)
+    # the supplied dB spectrum round-trips (dB -> linear on input, linear -> dB on return)
+    np.testing.assert_allclose(base0.powbase, np.zeros(nfreq), atol=1e-9)
+    np.testing.assert_allclose(base3.powbase, np.full(nfreq, 3.0), rtol=1e-9)
 
 
 def test_newtimef_baseline_forms_control_powbase_units():
@@ -269,26 +272,24 @@ def test_newtimef_single_trial_itc_is_unity():
 
 
 def test_newtimef_supplied_1d_bootstrap_thresholds_flag_extremes():
-    # A 1-D erspboot supplies a symmetric per-frequency band and a 1-D itcboot an upper
-    # magnitude threshold; supplied limits bypass the bootstrap and mask by comparison.
+    # A 1-D erspboot supplies a symmetric per-frequency band and a 1-D itcboot an upper magnitude
+    # threshold; supplied limits bypass the bootstrap and mask by comparison. (The dB / symmetric-band
+    # reading of a 1-D vector is an EEGPrep convention; EEGLAB documents pboot as an (nfreqs, 2) array.)
     srate = 128
     trials = _oscillation_trials(srate, 256, [0.0, 0.3, 0.6])
     common = dict(freqs=[6, 20], nfreqs=6, plot="off")
 
-    nfreq = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], **common).freqs.size
+    base = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], **common)
+    # per-frequency thresholds that straddle the data, so the masks are genuinely mixed
+    ersp_thresh = np.percentile(np.abs(base.ersp), 60, axis=1)
+    itc_thresh = np.percentile(np.abs(base.itc), 40, axis=1)
     result = newtimef(
-        trials,
-        256,
-        [0, 2000],
-        srate,
-        [3, 0.5],
-        alpha=0.05,
-        erspboot=np.full(nfreq, 0.5),
-        itcboot=np.full(nfreq, 0.3),
-        **common,
+        trials, 256, [0, 2000], srate, [3, 0.5], alpha=0.05, erspboot=ersp_thresh, itcboot=itc_thresh, **common
     )
-    np.testing.assert_array_equal(result.ersp_significant, np.abs(result.ersp) >= 0.5)
-    np.testing.assert_array_equal(result.itc_significant, np.abs(result.itc) >= 0.3)
+    np.testing.assert_array_equal(result.ersp_significant, np.abs(result.ersp) >= ersp_thresh[:, None])
+    np.testing.assert_array_equal(result.itc_significant, np.abs(result.itc) >= itc_thresh[:, None])
+    assert 0.0 < result.ersp_significant.mean() < 1.0  # mixed mask, not all-False/all-True
+    assert 0.0 < result.itc_significant.mean() < 1.0
 
 
 # --- timefreq numeric-parity regression guards (EEGLAB timefreq.m) ----------
@@ -1709,6 +1710,9 @@ def test_newtimef_matches_eeglab_ersp_itc_and_pvalues(tmp_path):
     np.testing.assert_allclose(result.ersp, matlab["P"], rtol=1e-6, atol=1e-6)  # ERSP (dB)
     np.testing.assert_allclose(result.itc, matlab["R"], rtol=1e-6, atol=1e-6)  # complex ITC
     np.testing.assert_allclose(py_pvals, matlab["pvals"], rtol=1e-12, atol=1e-12)  # two-sided compute_pvals
+    np.testing.assert_allclose(  # baseline spectrum in dB (EEGLAB mbase) -- the default log/baseline case
+        np.asarray(result.powbase).ravel(), np.asarray(matlab["mbase"]).ravel(), rtol=1e-6, atol=1e-6
+    )
 
 
 @pytest.mark.matlab
@@ -1933,6 +1937,8 @@ def test_bootstrap_itc_null_matches_eeglab_bootstat(tmp_path):
     # alignment, and ITC is recomputed. Bootstrap is random, so compare the converged
     # per-frequency null spread within a loose tolerance against real EEGLAB bootstat on
     # identical complex tf estimates (newtimef.m ITC path, phasecoher normalization).
+    # Note: naccu here counts full shuffles, whereas EEGLAB's dimaccu accumulates over time bins
+    # (~naccu/ntimes shuffles); the pooled distributions coincide, which is what this test checks.
     if os.environ.get("EEGPREP_SKIP_MATLAB") == "1":
         pytest.skip("MATLAB tests disabled via EEGPREP_SKIP_MATLAB")
     try:

--- a/tests/test_phase4_timefreq_statistics.py
+++ b/tests/test_phase4_timefreq_statistics.py
@@ -57,6 +57,7 @@ from eegprep.functions.timefreqfunc._pac_support import _empirical_pvalue as pac
 from eegprep.functions.timefreqfunc.newtimef import _is_on as newtimef_is_on
 from eegprep.functions.timefreqfunc.newtimef import (
     _baseline_pvalues,
+    _bootstrap_itc,
     _bootstrap_power,
     _reduce_to_two_ticks,
     _significance_mask,
@@ -1045,6 +1046,23 @@ def test_timefreq_threshold_helpers_pool_through_canonical_bootstrap_threshold()
     assert _upper_thresholds_by_frequency(single, alpha=0.1).shape == (1,)
 
 
+def test_bootstrap_threshold_matches_eeglab_tail_mean_formula():
+    # EEGLAB bootstat thresholds the sorted null at i = round(naccu*alpha) and averages the
+    # i most extreme surrogates on each requested side (bootstat.m accarray1/accarray2). Pin
+    # that tail selection and averaging with hand-computed values so a switch to a
+    # percentile-interpolation or floor(i) rule would fail loudly.
+    surrogates = np.arange(1.0, 21.0).reshape(20, 1)  # 20 sorted surrogates, one frequency
+
+    # alpha=0.1 -> i = round(20 * 0.1) = 2: mean of the two most extreme surrogates per side.
+    assert float(bootstrap_threshold(surrogates, alpha=0.1, bootside="upper")) == pytest.approx(19.5)  # mean(19, 20)
+    np.testing.assert_allclose(bootstrap_threshold(surrogates, alpha=0.1, bootside="both"), [1.5, 19.5])
+    # alpha=0.05 -> i = round(20 * 0.05) = 1: the single most extreme surrogate per side.
+    np.testing.assert_allclose(bootstrap_threshold(surrogates, alpha=0.05, bootside="both"), [1.0, 20.0])
+    # Complex surrogates are thresholded on magnitude (EEGLAB accarray = sqrt(x .* conj(x))).
+    complex_col = (np.arange(1.0, 21.0) * np.exp(1j * np.arange(20))).reshape(20, 1)
+    assert float(bootstrap_threshold(complex_col, alpha=0.05, bootside="upper")) == pytest.approx(20.0)
+
+
 def test_timefreq_shared_bootstrap_helpers_cover_newtimef_and_newcrossf_paths():
     times = np.asarray([-100.0, 0.0, 0.5, 100.0, 200.0])
     baseln = np.asarray([0, 1], dtype=int)
@@ -1753,6 +1771,63 @@ def test_bootstrap_power_null_matches_eeglab_bootstat(tmp_path):
         engine.quit()
 
     _, baseline_null = _bootstrap_power(power, "abs", alpha=0.05, naccu=naccu, base_indices=np.arange(n_base), rng=0)
+    py_null_std = np.std(baseline_null, axis=(0, 2))
+
+    matlab = scipy.io.loadmat(output, squeeze_me=True)
+    matlab_null_std = np.asarray(matlab["null_std"], dtype=float).ravel()
+    np.testing.assert_allclose(py_null_std, matlab_null_std, rtol=0.1)
+
+
+@pytest.mark.matlab
+def test_bootstrap_itc_null_matches_eeglab_bootstat(tmp_path):
+    # The ITC significance null must match EEGLAB bootstat's 'shuffle' permutation in
+    # distribution: shuffling each trial's baseline time course breaks the inter-trial phase
+    # alignment, and ITC is recomputed. Bootstrap is random, so compare the converged
+    # per-frequency null spread within a loose tolerance against real EEGLAB bootstat on
+    # identical complex tf estimates (newtimef.m ITC path, phasecoher normalization).
+    if os.environ.get("EEGPREP_SKIP_MATLAB") == "1":
+        pytest.skip("MATLAB tests disabled via EEGPREP_SKIP_MATLAB")
+    try:
+        matlab_engine = importlib.import_module("matlab.engine")
+    except ImportError as exc:
+        pytest.skip(f"MATLAB not available: {exc}")
+    eeglab_root = _eeglab_reference_root()
+    if eeglab_root is None:
+        pytest.skip("EEGLAB reference checkout not available")
+
+    rng = np.random.default_rng(0)
+    n_freq, n_base, n_trials = 5, 24, 16
+    naccu = 3000
+    # Complex tf estimates with partial inter-trial phase coherence (shared phase per time
+    # bin plus per-trial jitter), so the shuffle null has a non-trivial per-frequency spread.
+    mag = rng.gamma(3.0, 1.0, size=(n_freq, n_base, n_trials))
+    shared_phase = rng.uniform(-np.pi, np.pi, size=(n_freq, n_base))[:, :, None]
+    noise_phase = 0.6 * rng.standard_normal((n_freq, n_base, n_trials))
+    tf = mag * np.exp(1j * (shared_phase + noise_phase))
+
+    inputs = tmp_path / "bootstrap_itc_inputs.mat"
+    output = tmp_path / "bootstrap_itc_outputs.mat"
+    scipy.io.savemat(inputs, {"tf": tf})
+
+    engine = matlab_engine.start_matlab()
+    try:
+        engine.addpath(engine.genpath(str(eeglab_root / "functions")), nargout=0)
+        engine.eval(
+            f"""
+            load('{_matlab_string(inputs)}');
+            inputdata = tf ./ sqrt(tf .* conj(tf));  % phasecoher normalization (newtimef.m)
+            [~, ~, Rboottrials] = bootstat(inputdata, 'mean(arg1,3);', 'boottype', 'shuffle', ...
+                'basevect', 1:size(tf,2), 'naccu', {naccu}, 'alpha', 0.05, ...
+                'dimaccu', 2, 'bootside', 'upper');
+            null_std = std(Rboottrials, 0, 1);
+            save('{_matlab_string(output)}', 'null_std');
+            """,
+            nargout=0,
+        )
+    finally:
+        engine.quit()
+
+    _, baseline_null = _bootstrap_itc(tf, "phasecoher", alpha=0.05, naccu=naccu, base_indices=np.arange(n_base), rng=0)
     py_null_std = np.std(baseline_null, axis=(0, 2))
 
     matlab = scipy.io.loadmat(output, squeeze_me=True)

--- a/tests/test_phase4_timefreq_statistics.py
+++ b/tests/test_phase4_timefreq_statistics.py
@@ -225,6 +225,38 @@ def test_newtimef_supplied_powbase_shifts_ersp_by_db_offset():
     np.testing.assert_allclose(base3.ersp, base0.ersp - 3.0, rtol=1e-6, atol=1e-6)
 
 
+def test_newtimef_baseline_forms_control_powbase_units():
+    # The baseline guard must accept every EEGLAB baseline form. A multi-window (nested-list)
+    # baseline and an empty-list baseline are both enabled, so log-scale powbase comes back in dB
+    # (= 10*log10 of the absolute-scale powbase); a NaN baseline is disabled, so powbase stays in
+    # absolute power. Regression guard: a nested-list baseline previously crashed the guard.
+    srate = 128
+    trials = _oscillation_trials(srate, 256, [0.0, 0.3, 0.6])
+
+    def powbase(baseline, scale="log"):
+        result = newtimef(
+            trials,
+            256,
+            [-1000, 1000],
+            srate,
+            [3, 0.5],
+            freqs=[6, 20],
+            nfreqs=6,
+            baseline=baseline,
+            scale=scale,
+            plot="off",
+        )
+        return np.asarray(result.powbase).ravel()
+
+    for baseline in ([[-400, -200], [200, 400]], []):  # both enabled -> dB
+        log_db = powbase(baseline)
+        assert np.isfinite(log_db).all()
+        np.testing.assert_allclose(log_db, 10.0 * np.log10(powbase(baseline, scale="abs")), rtol=1e-6, atol=1e-6)
+
+    # NaN disables the baseline, so log-scale powbase stays in absolute power (as in EEGLAB)
+    np.testing.assert_allclose(powbase(np.nan), powbase(np.nan, scale="abs"), rtol=1e-6, atol=1e-6)
+
+
 def test_newtimef_single_trial_itc_is_unity():
     # With one trial, inter-trial coherence is trivially perfect: |itc| == 1 everywhere.
     srate = 128

--- a/tests/test_phase4_timefreq_statistics.py
+++ b/tests/test_phase4_timefreq_statistics.py
@@ -173,6 +173,92 @@ def test_newtimef_nonzero_cycles_use_wavelet_time_grid(sample_epoch):
     assert result.tfdata.shape == (result.freqs.size, result.times.size, sample_epoch["trials"])
 
 
+def test_newtimef_freqrange_alias_freqscale_and_scale_validation():
+    # freqrange aliases freqs; freqscale='log' spaces the output frequencies geometrically;
+    # an unknown scale fails fast.
+    srate = 128
+    trials = _oscillation_trials(srate, 256, [0.0, 0.3, 0.6])
+
+    aliased = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], freqrange=[6, 30], nfreqs=6, plot="off")
+    assert aliased.freqs.min() == pytest.approx(6.0)
+    assert aliased.freqs.max() == pytest.approx(30.0)
+
+    log_freqs = newtimef(
+        trials, 256, [0, 2000], srate, [3, 0.5], freqs=[6, 30], nfreqs=6, freqscale="log", plot="off"
+    ).freqs
+    ratios = log_freqs[1:] / log_freqs[:-1]
+    np.testing.assert_allclose(ratios, ratios[0], rtol=1e-6)  # constant ratio -> geometric spacing
+
+    with pytest.raises(ValueError, match="scale"):
+        newtimef(trials, 256, [0, 2000], srate, [3, 0.5], scale="bogus", plot="off")
+
+
+def test_newtimef_itctype_variants_and_type_alias():
+    # itctype selects the coherence statistic; all stay within the unit disk but differ,
+    # and 'type' is an accepted alias for 'itctype'.
+    srate = 128
+    trials = _oscillation_trials(srate, 256, [0.0, 0.4, 0.8, 1.2])
+    common = dict(freqs=[6, 20], nfreqs=6, plot="off")
+
+    default = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], **common)  # 'phasecoher'
+    coher = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], itctype="coher", **common)
+    pc2 = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], itctype="phasecoher2", **common)
+    for result in (default, coher, pc2):
+        assert result.itc.shape == default.itc.shape
+        assert np.all(np.abs(result.itc) <= 1 + 1e-9)
+    assert not np.allclose(default.itc, coher.itc)  # the statistic actually changes
+
+    aliased = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], type="coher", **common)
+    np.testing.assert_allclose(aliased.itc, coher.itc)
+
+
+def test_newtimef_supplied_powbase_shifts_ersp_by_db_offset():
+    # A supplied baseline spectrum (dB) sets the log-power baseline directly; raising it by
+    # K dB lowers the whole ERSP by K dB (EEGLAB log-subtracts the supplied powbase).
+    srate = 128
+    trials = _oscillation_trials(srate, 256, [0.0, 0.3, 0.6])
+    common = dict(freqs=[6, 20], nfreqs=6, plot="off")
+
+    nfreq = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], **common).freqs.size
+    base0 = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], powbase=np.zeros(nfreq), **common)
+    base3 = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], powbase=np.full(nfreq, 3.0), **common)
+    np.testing.assert_allclose(base3.ersp, base0.ersp - 3.0, rtol=1e-6, atol=1e-6)
+
+
+def test_newtimef_single_trial_itc_is_unity():
+    # With one trial, inter-trial coherence is trivially perfect: |itc| == 1 everywhere.
+    srate = 128
+    signal = np.sin(2 * np.pi * 10 * np.arange(256) / srate)
+
+    result = newtimef(signal, 256, [0, 2000], srate, [3, 0.5], freqs=[6, 20], nfreqs=6, plot="off")
+
+    assert result.tfdata.shape[2] == 1
+    np.testing.assert_allclose(np.abs(result.itc), 1.0, atol=1e-9)
+
+
+def test_newtimef_supplied_1d_bootstrap_thresholds_flag_extremes():
+    # A 1-D erspboot supplies a symmetric per-frequency band and a 1-D itcboot an upper
+    # magnitude threshold; supplied limits bypass the bootstrap and mask by comparison.
+    srate = 128
+    trials = _oscillation_trials(srate, 256, [0.0, 0.3, 0.6])
+    common = dict(freqs=[6, 20], nfreqs=6, plot="off")
+
+    nfreq = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], **common).freqs.size
+    result = newtimef(
+        trials,
+        256,
+        [0, 2000],
+        srate,
+        [3, 0.5],
+        alpha=0.05,
+        erspboot=np.full(nfreq, 0.5),
+        itcboot=np.full(nfreq, 0.3),
+        **common,
+    )
+    np.testing.assert_array_equal(result.ersp_significant, np.abs(result.ersp) >= 0.5)
+    np.testing.assert_array_equal(result.itc_significant, np.abs(result.itc) >= 0.3)
+
+
 # --- timefreq numeric-parity regression guards (EEGLAB timefreq.m) ----------
 
 
@@ -893,6 +979,36 @@ def test_newtimef_curve_mode_still_plots_per_frequency_lines():
     assert result.figure.axes  # curve figure is produced
     assert any(axis.get_lines() for axis in result.figure.axes)  # per-frequency traces, not an image
     assert not any(axis.get_images() for axis in result.figure.axes)
+    plt.close(result.figure)
+
+
+def test_newtimef_single_panel_figures():
+    # plotitc='off' draws only the ERSP image; plotersp='off' draws only the ITC image.
+    srate = 128
+    trials = _oscillation_trials(srate, 256, [0.0, 0.3, 0.6])
+    common = dict(freqs=[6, 20], nfreqs=6, timesout=12)
+
+    ersp_only = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], plotitc="off", **common)
+    itc_only = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], plotersp="off", **common)
+
+    assert len([im for ax in ersp_only.figure.axes for im in ax.get_images()]) == 1
+    assert len([im for ax in itc_only.figure.axes for im in ax.get_images()]) == 1
+    assert any(title.startswith("ERSP(") for title in [ax.get_title() for ax in ersp_only.figure.axes])
+    assert "ITC" in [ax.get_title() for ax in itc_only.figure.axes]
+    plt.close(ersp_only.figure)
+    plt.close(itc_only.figure)
+
+
+def test_newtimef_vert_markers_drawn_on_image_panels():
+    # A 'vert' marker draws a vertical line on the image panel (besides the time-0 marker).
+    srate = 128
+    trials = _oscillation_trials(srate, 256, [0.0, 0.3, 0.6])
+    marker = 500.0  # ms, inside the epoch
+
+    result = newtimef(trials, 256, [0, 2000], srate, [3, 0.5], freqs=[6, 20], nfreqs=6, vert=[marker])
+
+    ersp_axis = [im for ax in result.figure.axes for im in ax.get_images()][0].axes
+    assert any(np.allclose(line.get_xdata(), marker) for line in ersp_axis.get_lines())
     plt.close(result.figure)
 
 

--- a/tests/test_phase4_timefreq_statistics.py
+++ b/tests/test_phase4_timefreq_statistics.py
@@ -1546,6 +1546,91 @@ def test_newtimef_matches_eeglab_ersp_itc_and_pvalues(tmp_path):
 
 
 @pytest.mark.matlab
+def test_newtimef_scale_and_baseline_modes_match_eeglab(tmp_path):
+    # Parity for the option paths the deterministic end-to-end test above does not exercise:
+    # absolute power scale, baseline normalization (basenorm), single-trial baseline (trialbase 'full'),
+    # and the cycles=0 short-time FFT path. Each case is deterministic, so P (ERSP), R (complex ITC),
+    # and mbase (baseline spectrum) match EEGLAB tightly. mbase in particular guards the units EEGLAB
+    # returns: dB for the default log scale (newtimef.m:1399), absolute power for abs/basenorm/trialbase.
+    if os.environ.get("EEGPREP_SKIP_MATLAB") == "1":
+        pytest.skip("MATLAB tests disabled via EEGPREP_SKIP_MATLAB")
+    try:
+        matlab_engine = importlib.import_module("matlab.engine")
+    except ImportError as exc:
+        pytest.skip(f"MATLAB not available: {exc}")
+    eeglab_root = _eeglab_reference_root()
+    if eeglab_root is None:
+        pytest.skip("EEGLAB reference checkout not available")
+
+    srate = 128.0
+    n_frames = 128
+    tlimits = [-500, 500]
+    sample_times = np.arange(n_frames) / srate
+    envelope = 1.0 + (sample_times > 0.5)  # amplitude step mid-epoch -> a non-trivial ERSP
+    trials = np.stack(
+        [
+            envelope * np.sin(2 * np.pi * 10 * sample_times + phase) + 0.5 * np.sin(2 * np.pi * 6 * sample_times)
+            for phase in np.linspace(0.0, 1.2, 12)
+        ],
+        axis=1,
+    )
+    # Output times on exact frame centers well inside the valid range, so both engines pick identical frames.
+    frame_times = tlimits[0] + np.arange(n_frames) * (tlimits[1] - tlimits[0]) / (n_frames - 1)
+    timesout = frame_times[[44, 52, 60, 68, 76, 82]]
+
+    inputs = tmp_path / "newtimef_modes_inputs.mat"
+    output = tmp_path / "newtimef_modes_outputs.mat"
+    scipy.io.savemat(inputs, {"data": trials, "timesout": timesout})
+
+    engine = matlab_engine.start_matlab()
+    try:
+        engine.addpath(engine.genpath(str(eeglab_root / "functions")), nargout=0)
+        engine.eval(
+            f"""
+            load('{_matlab_string(inputs)}');
+            set(0, 'DefaultFigureVisible', 'off');
+            common = {{'freqs', [5 20], 'nfreqs', 8, 'timesout', timesout, 'baseline', [-200 0], ...
+                      'plotphase', 'off', 'verbose', 'off'}};
+            [abs_P, abs_R, abs_mbase, abs_times, abs_freqs] = ...
+                newtimef(data, {n_frames}, [{tlimits[0]} {tlimits[1]}], {srate}, [3 0.5], 'scale', 'abs', common{{:}});
+            [bn_P, bn_R, bn_mbase] = ...
+                newtimef(data, {n_frames}, [{tlimits[0]} {tlimits[1]}], {srate}, [3 0.5], 'basenorm', 'on', common{{:}});
+            [tb_P, tb_R, tb_mbase] = ...
+                newtimef(data, {n_frames}, [{tlimits[0]} {tlimits[1]}], {srate}, [3 0.5], 'trialbase', 'full', common{{:}});
+            [fft_P, fft_R, fft_mbase] = ...
+                newtimef(data, {n_frames}, [{tlimits[0]} {tlimits[1]}], {srate}, 0, 'padratio', 2, common{{:}});
+            close all;
+            save('{_matlab_string(output)}', 'abs_P', 'abs_R', 'abs_mbase', 'abs_times', 'abs_freqs', ...
+                 'bn_P', 'bn_R', 'bn_mbase', 'tb_P', 'tb_R', 'tb_mbase', 'fft_P', 'fft_R', 'fft_mbase');
+            """,
+            nargout=0,
+        )
+    finally:
+        engine.quit()
+
+    common = dict(freqs=[5, 20], nfreqs=8, timesout=timesout, baseline=[-200, 0], plotphase="off", plot="off")
+    results = {
+        "abs": newtimef(trials, n_frames, tlimits, srate, [3, 0.5], scale="abs", **common),
+        "bn": newtimef(trials, n_frames, tlimits, srate, [3, 0.5], basenorm="on", **common),
+        "tb": newtimef(trials, n_frames, tlimits, srate, [3, 0.5], trialbase="full", **common),
+        "fft": newtimef(trials, n_frames, tlimits, srate, 0, padratio=2, **common),
+    }
+
+    matlab = scipy.io.loadmat(output, squeeze_me=True)
+    np.testing.assert_allclose(results["abs"].freqs, np.asarray(matlab["abs_freqs"]).ravel(), rtol=1e-9, atol=1e-9)
+    np.testing.assert_allclose(results["abs"].times, np.asarray(matlab["abs_times"]).ravel(), rtol=1e-9, atol=1e-9)
+    for case in ("abs", "bn", "tb", "fft"):
+        np.testing.assert_allclose(results[case].ersp, matlab[f"{case}_P"], rtol=1e-6, atol=1e-6)  # ERSP
+        np.testing.assert_allclose(results[case].itc, matlab[f"{case}_R"], rtol=1e-6, atol=1e-6)  # complex ITC
+        np.testing.assert_allclose(  # baseline spectrum: dB for the log FFT case, absolute power otherwise
+            np.asarray(results[case].powbase, dtype=float).ravel(),
+            np.asarray(matlab[f"{case}_mbase"], dtype=float).ravel(),
+            rtol=1e-6,
+            atol=1e-6,
+        )
+
+
+@pytest.mark.matlab
 def test_timefreq_negative_ntimesout_times_match_eeglab(tmp_path):
     # Ground-truth the negative-ntimesout subsample grid against real EEGLAB timefreq (not a
     # hand-encoded colon formula): the trickiest off-by-one in the decomposition is np.arange's


### PR DESCRIPTION
newtimef and pop_newtimef now return the baseline spectrum (powbase) in dB for the default log scale, matching EEGLAB's mbase; it was previously returned in absolute power, and the plotted figure is unchanged. Adds MATLAB parity tests for the scale, basenorm, trialbase, and FFT paths and the ITC bootstrap null, plus behavior tests for the freqscale, itctype, powbase, single-trial, single-panel, and vert options, raising newtimef coverage to 94 percent.